### PR TITLE
infer-log-tips-idx-error

### DIFF
--- a/contrib/infer.py
+++ b/contrib/infer.py
@@ -121,7 +121,7 @@ def infer():
         if (idx + 1) % 100 == 0:
             print('%d  processd' % (idx + 1))
             
-    print('%d  processd done' % (idx + 1))   
+    print('%d  processd done' % (data_num))   
     
     return 0
 


### PR DESCRIPTION
UnboundLocalError: local variable 'idx' referenced before assignment