### PR TITLE
add profiler for models

### DIFF
--- a/pdseg/train.py
+++ b/pdseg/train.py
@@ -32,6 +32,7 @@ import paddle
 import numpy as np
 import paddle.fluid as fluid
 
+from paddle.fluid import profiler
 from utils.config import cfg
 from utils.timer import Timer, calculate_eta
 from metrics import ConfusionMatrix
@@ -102,6 +103,18 @@ def parse_args():
         help='If set True, enable continuous evaluation job.'
         'This flag is only used for internal test.',
         action='store_true')
+    
+    # NOTE: This for benchmark
+    parser.add_argument(
+        '--is_profiler',
+        help='the profiler switch.(used for benchmark)',
+        default=0,
+        type=int)
+    parser.add_argument(
+        '--profiler_path',
+        help='the profiler output file path.(used for benchmark)',
+        default='./deeplabv3.profiler',
+        type=str) 
     return parser.parse_args()
 
 
@@ -441,6 +454,13 @@ def train(cfg):
                         sys.stdout.flush()
                         avg_loss = 0.0
                         timer.restart()
+                     
+                    # NOTE : used for benchmark, profiler tools
+                    if args.is_profiler and epoch == 1 and global_step == args.log_steps: 
+                        profiler.start_profiler("All")
+                    elif args.is_profiler and epoch == 1 and global_step == args.log_steps + 5:
+                        profiler.stop_profiler("total", args.profiler_path)
+                        return
 
             except fluid.core.EOFException:
                 py_reader.reset()


### PR DESCRIPTION
 * add profiler tools for models, needed in benchmark
   *  modified pdseg/train.py, add two new args, --is_profiler(the switch of profiler) and --profiler_path(the path to save profiler files)