### PR TITLE
添加传参

### DIFF
--- a/deploy/python/infer.py
+++ b/deploy/python/infer.py
@@ -295,7 +295,7 @@ class Predictor:
 
 def run(deploy_conf, imgs_dir, support_extensions=".jpg|.jpeg"):
     # 1. scan and get all images with valid extensions in directory imgs_dir
-    imgs = get_images_from_dir(imgs_dir)
+    imgs = get_images_from_dir(imgs_dir, support_extensions)
     if len(imgs) == 0:
         print("No Image (with extensions : %s) found in [%s]" %
               (support_extensions, imgs_dir))


### PR DESCRIPTION
在 298 行调用 get_images_from_dir 时，文件后缀忘传了，导致infer脚本只能推理 jpg或jpeg 格式的图片。本地测试修改后执行正常