### PR TITLE
Ignore previous inference results in infer.py

### DIFF
--- a/deploy/python/README.md
+++ b/deploy/python/README.md
@@ -92,7 +92,7 @@ python infer.py --conf=/path/to/deploy.yaml --input_dir=/path/to/images_director
 
 运行后程序会扫描`input_dir` 目录下所有指定格式图片，并生成`预测mask`和`可视化的结果`。
 
-对于图片`a.jpeg`, `预测mask` 存在`a_jpeg.png` 中，而可视化结果则在`a_jpeg_result.png` 中。
+对于图片`a.jpeg`, `预测mask` 存在`a_jpeg_mask.png` 中，而可视化结果则在`a_jpeg_result.png` 中。
 
 输入样例:
 ![avatar](../cpp/images/humanseg/demo2.jpeg)

--- a/deploy/python/infer.py
+++ b/deploy/python/infer.py
@@ -59,12 +59,16 @@ trt_precision_map = {
 }
 
 
-# scan a directory and get all images with support extensions
+# scan a directory and get all images with support extensions(will ignore *_mask.* and *_result.*)
 def get_images_from_dir(img_dir, support_ext=".jpg|.jpeg"):
     if (not os.path.exists(img_dir) or not os.path.isdir(img_dir)):
         raise Exception("Image Directory [%s] invalid" % img_dir)
     imgs = []
     for item in os.listdir(img_dir):
+        name, ext = os.path.splitext(item)
+        ext = ext[1:].strip().lower()
+        if name.endswith("_mask") or name.endswith("_result"):
+            continue
         ext = os.path.splitext(item)[1][1:].strip().lower()
         if (len(ext) > 0 and ext in support_ext):
             item_path = os.path.join(img_dir, item)


### PR DESCRIPTION
在获取所有推理输入列表时忽略 _mask 和 _result 结尾文件，不对推理结果再进行推理。
一个文件夹下的数据多次用不同权重推理总是需要删推理结果，不太方便。本地测试通过