### PR TITLE
add requirements.txt for dygraph mode

### DIFF
--- a/dygraph/requirements.txt
+++ b/dygraph/requirements.txt
@@ -1,0 +1,5 @@
+pre-commit
+yapf == 0.26.0
+flake8
+pyyaml >= 5.1
+visualdl >= 2.0.0


### PR DESCRIPTION
Note: 关于opencv依赖问题，Paddle会自动安装opencv。
对于Paddle2.0 beta会安装opencv 4.4，并有以下提示
```
paddlepaddle-gpu 2.0.0b0 requires opencv-python<=4.2.0.32, but you'll have opencv-python 4.4.0.44 which is incompatible.
```
经测试未发现有任何影响。

对于Paddle2.0 develop会安装opencv 4.2，不会有兼容问题。