### PR TITLE
add opencv, tqdm dependency

### DIFF
--- a/dygraph/requirements.txt
+++ b/dygraph/requirements.txt
@@ -3,3 +3,5 @@ yapf == 0.26.0
 flake8
 pyyaml >= 5.1
 visualdl >= 2.0.0
+opencv-python
+tqdm


### PR DESCRIPTION
由于paddle rc版移除了一些依赖，paddleseg需要补上