### PR TITLE
Calculate and print the average time

### DIFF
--- a/paddleseg/core/train.py
+++ b/paddleseg/core/train.py
@@ -20,7 +20,7 @@ import shutil
 import paddle
 import paddle.nn.functional as F
 
-from paddleseg.utils import Timer, calculate_eta, resume, logger
+from paddleseg.utils import TimeAverager, calculate_eta, resume, logger
 from paddleseg.core.val import evaluate
 
 
@@ -112,16 +112,15 @@ def train(model,
         from visualdl import LogWriter
         log_writer = LogWriter(save_dir)
 
-    timer = Timer()
     avg_loss = 0.0
     avg_loss_list = []
     iters_per_epoch = len(batch_sampler)
     best_mean_iou = -1.0
     best_model_iter = -1
-    train_reader_cost = 0.0
-    train_batch_cost = 0.0
+    reader_cost_averager = TimeAverager()
+    batch_cost_averager = TimeAverager()
     save_models = deque()
-    timer.start()
+    batch_start = time.time()
 
     iter = start_iter
     while iter < iters:
@@ -129,7 +128,7 @@ def train(model,
             iter += 1
             if iter > iters:
                 break
-            train_reader_cost += timer.elapsed_time()
+            reader_cost_averager.record(time.time() - batch_start)
             images = data[0]
             labels = data[1].astype('int64')
             edges = None
@@ -160,24 +159,24 @@ def train(model,
             else:
                 for i in range(len(loss_list)):
                     avg_loss_list[i] += loss_list[i]
-            train_batch_cost += timer.elapsed_time()
+            batch_cost_averager.record(
+                    time.time() - batch_start,
+                    num_samples=batch_size)
 
             if (iter) % log_iters == 0 and local_rank == 0:
                 avg_loss /= log_iters
                 avg_loss_list = [
                     l.numpy()[0] / log_iters for l in avg_loss_list
                 ]
-                avg_train_reader_cost = train_reader_cost / log_iters
-                avg_train_batch_cost = train_batch_cost / log_iters
-                train_reader_cost = 0.0
-                train_batch_cost = 0.0
                 remain_iters = iters - iter
+                avg_train_batch_cost = batch_cost_averager.get_average()
+                avg_train_reader_cost = reader_cost_averager.get_average()
                 eta = calculate_eta(remain_iters, avg_train_batch_cost)
                 logger.info(
-                    "[TRAIN] epoch={}, iter={}/{}, loss={:.4f}, lr={:.6f}, batch_cost={:.4f}, reader_cost={:.4f} | ETA {}"
+                    "[TRAIN] epoch={}, iter={}/{}, loss={:.4f}, lr={:.6f}, batch_cost={:.4f}, reader_cost={:.4f}, ips={:.4f} samples/sec | ETA {}"
                     .format((iter - 1) // iters_per_epoch + 1, iter, iters,
                             avg_loss, lr, avg_train_batch_cost,
-                            avg_train_reader_cost, eta))
+                            avg_train_reader_cost, batch_cost_averager.get_ips_average(), eta))
                 if use_vdl:
                     log_writer.add_scalar('Train/loss', avg_loss, iter)
                     # Record all losses if there are more than 2 losses.
@@ -196,6 +195,8 @@ def train(model,
                                           avg_train_reader_cost, iter)
                 avg_loss = 0.0
                 avg_loss_list = []
+                reader_cost_averager.reset()
+                batch_cost_averager.reset()
 
             if (iter % save_interval == 0
                     or iter == iters) and (val_dataset is not None):
@@ -233,7 +234,7 @@ def train(model,
                     if use_vdl:
                         log_writer.add_scalar('Evaluate/mIoU', mean_iou, iter)
                         log_writer.add_scalar('Evaluate/Acc', acc, iter)
-            timer.restart()
+            batch_start = time.time()
 
     # Calculate flops.
     if local_rank == 0:

--- a/paddleseg/core/train.py
+++ b/paddleseg/core/train.py
@@ -173,7 +173,7 @@ def train(model,
                 avg_train_reader_cost = reader_cost_averager.get_average()
                 eta = calculate_eta(remain_iters, avg_train_batch_cost)
                 logger.info(
-                    "[TRAIN] epoch={}, iter={}/{}, loss={:.4f}, lr={:.6f}, batch_cost={:.4f}, reader_cost={:.4f}, ips={:.4f} samples/sec | ETA {}"
+                    "[TRAIN] epoch={}, iter={}/{}, loss={:.4f}, lr={:.6f}, batch_cost={:.4f}, reader_cost={:.5f}, ips={:.4f} samples/sec | ETA {}"
                     .format((iter - 1) // iters_per_epoch + 1, iter, iters,
                             avg_loss, lr, avg_train_batch_cost,
                             avg_train_reader_cost, batch_cost_averager.get_ips_average(), eta))

--- a/paddleseg/core/val.py
+++ b/paddleseg/core/val.py
@@ -145,10 +145,12 @@ def evaluate(model,
             batch_cost_averager.record(
                     time.time() - batch_start,
                     num_samples=len(label))
+            batch_cost = batch_cost_averager.get_average()
+            reader_cost = reader_cost_averager.get_average()
 
             if local_rank == 0:
-                progbar_val.update(iter + 1, [('batch_cost', batch_cost_averager.get_average()),
-                                              ('reader cost', reader_cost_averager.get_average())])
+                progbar_val.update(iter + 1, [('batch_cost', batch_cost),
+                                              ('reader cost', reader_cost)])
             reader_cost_averager.reset()
             batch_cost_averager.reset()
             batch_start = time.time()

--- a/paddleseg/core/val.py
+++ b/paddleseg/core/val.py
@@ -15,10 +15,11 @@
 import os
 
 import numpy as np
+import time
 import paddle
 import paddle.nn.functional as F
 
-from paddleseg.utils import metrics, Timer, calculate_eta, logger, progbar
+from paddleseg.utils import metrics, TimeAverager, calculate_eta, logger, progbar
 from paddleseg.core import infer
 
 np.set_printoptions(suppress=True)
@@ -80,10 +81,12 @@ def evaluate(model,
     logger.info("Start evaluating (total_samples={}, total_iters={})...".format(
         len(eval_dataset), total_iters))
     progbar_val = progbar.Progbar(target=total_iters, verbose=1)
-    timer = Timer()
+    reader_cost_averager = TimeAverager()
+    batch_cost_averager = TimeAverager()
+    batch_start = time.time()
     with paddle.no_grad():
         for iter, (im, label) in enumerate(loader):
-            reader_cost = timer.elapsed_time()
+            reader_cost_averager.record(time.time() - batch_start)
             label = label.astype('int64')
 
             ori_shape = label.shape[-2:]
@@ -139,12 +142,16 @@ def evaluate(model,
                 intersect_area_all = intersect_area_all + intersect_area
                 pred_area_all = pred_area_all + pred_area
                 label_area_all = label_area_all + label_area
-            batch_cost = timer.elapsed_time()
-            timer.restart()
+            batch_cost_averager.record(
+                    time.time() - batch_start,
+                    num_samples=len(label))
 
             if local_rank == 0:
-                progbar_val.update(iter + 1, [('batch_cost', batch_cost),
-                                              ('reader cost', reader_cost)])
+                progbar_val.update(iter + 1, [('batch_cost', batch_cost_averager.get_average()),
+                                              ('reader cost', reader_cost_averager.get_average())])
+            reader_cost_averager.reset()
+            batch_cost_averager.reset()
+            batch_start = time.time()
 
     class_iou, miou = metrics.mean_iou(intersect_area_all, pred_area_all,
                                        label_area_all)

--- a/paddleseg/utils/__init__.py
+++ b/paddleseg/utils/__init__.py
@@ -17,5 +17,5 @@ from . import download
 from . import metrics
 from .env import seg_env, get_sys_env
 from .utils import *
-from .timer import Timer, calculate_eta
+from .timer import TimeAverager, calculate_eta
 from . import visualize

--- a/paddleseg/utils/timer.py
+++ b/paddleseg/utils/timer.py
@@ -15,37 +15,30 @@
 import time
 
 
-class Timer(object):
-    """ Simple timer class for measuring time consuming """
-
+class TimeAverager(object):
     def __init__(self):
-        self._start_time = 0.0
-        self._end_time = 0.0
-        self._elapsed_time = 0.0
-        self._is_running = False
+        self.reset()
 
-    def start(self):
-        self._is_running = True
-        self._start_time = time.time()
+    def reset(self):
+        self._cnt = 0
+        self._total_time = 0
+        self._total_samples = 0
 
-    def restart(self):
-        self.start()
+    def record(self, usetime, num_samples=None):
+        self._cnt += 1
+        self._total_time += usetime
+        if num_samples:
+            self._total_samples += num_samples
 
-    def stop(self):
-        self._is_running = False
-        self._end_time = time.time()
+    def get_average(self):
+        if self._cnt == 0:
+            return 0
+        return self._total_time / float(self._cnt)
 
-    def elapsed_time(self):
-        self._end_time = time.time()
-        self._elapsed_time = self._end_time - self._start_time
-        if not self.is_running:
-            return 0.0
-
-        return self._elapsed_time
-
-    @property
-    def is_running(self):
-        return self._is_running
+    def get_ips_average(self):
+        if not self._total_samples or self._cnt == 0:
+            return 0
+        return float(self._total_samples) / self._total_time
 
 
 def calculate_eta(remaining_step, speed):


### PR DESCRIPTION
根据benchmark标准化，增加ips统计
## train
- before
```
2021-01-19 07:02:41 [INFO]	[TRAIN] epoch=1, iter=5/100, loss=2.8735, lr=0.009639, batch_cost=0.8913, reader_cost=0.2592 | ETA 00:01:24
2021-01-19 07:02:44 [INFO]	[TRAIN] epoch=1, iter=10/100, loss=2.2584, lr=0.009186, batch_cost=0.6143, reader_cost=0.0000 | ETA 00:00:55
2021-01-19 07:02:47 [INFO]	[TRAIN] epoch=1, iter=15/100, loss=1.6819, lr=0.008731, batch_cost=0.6180, reader_cost=0.0000 | ETA 00:00:52
2021-01-19 07:02:50 [INFO]	[TRAIN] epoch=1, iter=20/100, loss=2.2924, lr=0.008272, batch_cost=0.5972, reader_cost=0.0000 | ETA 00:00:47
2021-01-19 07:02:53 [INFO]	[TRAIN] epoch=1, iter=25/100, loss=1.4582, lr=0.007811, batch_cost=0.5986, reader_cost=0.0000 | ETA 00:00:44
2021-01-19 07:02:56 [INFO]	[TRAIN] epoch=1, iter=30/100, loss=1.5533, lr=0.007347, batch_cost=0.5996, reader_cost=0.0000 | ETA 00:00:41
2021-01-19 07:02:59 [INFO]	[TRAIN] epoch=1, iter=35/100, loss=1.4564, lr=0.006880, batch_cost=0.5977, reader_cost=0.0000 | ETA 00:00:38
2021-01-19 07:03:02 [INFO]	[TRAIN] epoch=1, iter=40/100, loss=1.5977, lr=0.006409, batch_cost=0.5996, reader_cost=0.0000 | ETA 00:00:35
2021-01-19 07:03:05 [INFO]	[TRAIN] epoch=1, iter=45/100, loss=2.1524, lr=0.005934, batch_cost=0.5987, reader_cost=0.0000 | ETA 00:00:32
2021-01-19 07:03:08 [INFO]	[TRAIN] epoch=1, iter=50/100, loss=1.9311, lr=0.005455, batch_cost=0.5986, reader_cost=0.0001 | ETA 00:00:29
2021-01-19 07:03:11 [INFO]	[TRAIN] epoch=1, iter=55/100, loss=1.8286, lr=0.004971, batch_cost=0.6020, reader_cost=0.0000 | ETA 00:00:27
2021-01-19 07:03:14 [INFO]	[TRAIN] epoch=1, iter=60/100, loss=1.9385, lr=0.004482, batch_cost=0.6111, reader_cost=0.0000 | ETA 00:00:24
```
- after
```
2021-01-19 06:22:40 [INFO]	[TRAIN] epoch=1, iter=5/200, loss=3.2654, lr=0.009820, batch_cost=0.8908, reader_cost=0.23125, ips=2.2453 samples/sec | ETA 00:02:53
2021-01-19 06:22:43 [INFO]	[TRAIN] epoch=1, iter=10/200, loss=2.5065, lr=0.009594, batch_cost=0.6130, reader_cost=0.00006, ips=3.2627 samples/sec | ETA 00:01:56
2021-01-19 06:22:46 [INFO]	[TRAIN] epoch=1, iter=15/200, loss=1.8656, lr=0.009368, batch_cost=0.6032, reader_cost=0.00006, ips=3.3154 samples/sec | ETA 00:01:51
2021-01-19 06:22:49 [INFO]	[TRAIN] epoch=1, iter=20/200, loss=1.9855, lr=0.009141, batch_cost=0.5995, reader_cost=0.00007, ips=3.3361 samples/sec | ETA 00:01:47
2021-01-19 06:22:52 [INFO]	[TRAIN] epoch=1, iter=25/200, loss=1.6710, lr=0.008913, batch_cost=0.5994, reader_cost=0.00006, ips=3.3366 samples/sec | ETA 00:01:44
2021-01-19 06:22:55 [INFO]	[TRAIN] epoch=1, iter=30/200, loss=1.7677, lr=0.008685, batch_cost=0.5915, reader_cost=0.00005, ips=3.3814 samples/sec | ETA 00:01:40
2021-01-19 06:22:58 [INFO]	[TRAIN] epoch=1, iter=35/200, loss=1.6532, lr=0.008456, batch_cost=0.5997, reader_cost=0.00005, ips=3.3350 samples/sec | ETA 00:01:38
2021-01-19 06:23:01 [INFO]	[TRAIN] epoch=1, iter=40/200, loss=2.0951, lr=0.008227, batch_cost=0.6024, reader_cost=0.00006, ips=3.3202 samples/sec | ETA 00:01:36
2021-01-19 06:23:04 [INFO]	[TRAIN] epoch=1, iter=45/200, loss=1.6151, lr=0.007996, batch_cost=0.5931, reader_cost=0.00004, ips=3.3721 samples/sec | ETA 00:01:31
2021-01-19 06:23:07 [INFO]	[TRAIN] epoch=1, iter=50/200, loss=1.7092, lr=0.007765, batch_cost=0.6057, reader_cost=0.00026, ips=3.3021 samples/sec | ETA 00:01:30
2021-01-19 06:23:10 [INFO]	[TRAIN] epoch=1, iter=55/200, loss=1.7479, lr=0.007533, batch_cost=0.5985, reader_cost=0.00005, ips=3.3417 samples/sec | ETA 00:01:26
2021-01-19 06:23:13 [INFO]	[TRAIN] epoch=1, iter=60/200, loss=1.8309, lr=0.007301, batch_cost=0.5953, reader_cost=0.00005, ips=3.3597 samples/sec | ETA 00:01:23
```
## eval
- before
```
500/500 [==============================] - 118s 236ms/step - batch_cost: 0.2354 - reader cost: 0.0198
```
- after
```
500/500 [==============================] - 119s 237ms/step - batch_cost: 0.2371 - reader cost: 0.0421
```