### PR TITLE
Fix ignore_index of dice_loss

### DIFF
--- a/paddleseg/models/losses/dice_loss.py
+++ b/paddleseg/models/losses/dice_loss.py
@@ -26,28 +26,35 @@ class DiceLoss(nn.Layer):
             and does not contribute to the input gradient. Default ``255``.
     """
 
-    def __init__(self, ignore_index=255):
+    def __init__(self, ignore_index=255, smooth=0.):
         super(DiceLoss, self).__init__()
         self.ignore_index = ignore_index
         self.eps = 1e-5
+        self.smooth = smooth # Laplace smoothing, https://github.com/pytorch/pytorch/issues/1249#issuecomment-337999895
 
     def forward(self, logits, labels):
         if len(labels.shape) != len(logits.shape):
             labels = paddle.unsqueeze(labels, 1)
         num_classes = logits.shape[1]
-        mask = (labels != self.ignore_index)
-        logits = logits * mask
+
         labels = paddle.cast(labels, dtype='int32')
         single_label_lists = []
         for c in range(num_classes):
             single_label = paddle.cast((labels == c), dtype='int32')
             single_label = paddle.squeeze(single_label, axis=1)
+            if c == self.ignore_index:
+                single_label = paddle.zeros_like(single_label)
             single_label_lists.append(single_label)
+
         labels_one_hot = paddle.stack(tuple(single_label_lists), axis=1)
         logits = F.softmax(logits, axis=1)
+
+        mask = (labels != self.ignore_index)
+        logits = logits * mask
+
         labels_one_hot = paddle.cast(labels_one_hot, dtype='float32')
         dims = (0,) + tuple(range(2, labels.ndimension()))
         intersection = paddle.sum(logits * labels_one_hot, dims)
         cardinality = paddle.sum(logits + labels_one_hot, dims)
-        dice_loss = (2. * intersection / (cardinality + self.eps)).mean()
+        dice_loss = ((2. * intersection + self.smooth) / (cardinality + self.eps + self.smooth)).mean()
         return 1 - dice_loss


### PR DESCRIPTION
原先的dice_loss实现，其中ignore_index参数并未真实发挥作用，仅对logits做了mask，使得被忽略的类别上logits的值为0。但这一操作在softmax之后不能确保对应类别概率为0，且未处理对应类别的label，因而被忽略的类别上仍然存在one_hot的label。

另外增加 smooth参数，据称这一操作可以使dice_loss收敛更快更平滑。使用时设置为1即可