### PR TITLE
update pdseg prediction codes with new benchmark log

### DIFF
--- a/tools/infer/benchmark_utils.py
+++ b/tools/infer/benchmark_utils.py
@@ -1,0 +1,279 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import time
+import logging
+
+import paddle
+import paddle.inference as paddle_infer
+
+from pathlib import Path
+
+CUR_DIR = os.path.dirname(os.path.abspath(__file__))
+LOG_PATH_ROOT = f"{CUR_DIR}/../../output"
+
+
+class PaddleInferBenchmark(object):
+    def __init__(self,
+                 config,
+                 model_info: dict = {},
+                 data_info: dict = {},
+                 perf_info: dict = {},
+                 resource_info: dict = {},
+                 **kwargs):
+        """
+        Construct PaddleInferBenchmark Class to format logs.
+        args:
+            config(paddle.inference.Config): paddle inference config
+            model_info(dict): basic model info
+                {'model_name': 'resnet50'
+                 'precision': 'fp32'}
+            data_info(dict): input data info
+                {'batch_size': 1
+                 'shape': '3,224,224'
+                 'data_num': 1000}
+            perf_info(dict): performance result
+                {'preprocess_time_s': 1.0
+                'inference_time_s': 2.0
+                'postprocess_time_s': 1.0
+                'total_time_s': 4.0}
+            resource_info(dict):
+                cpu and gpu resources
+                {'cpu_rss': 100
+                 'gpu_rss': 100
+                 'gpu_util': 60}
+        """
+        # PaddleInferBenchmark Log Version
+        self.log_version = "1.0.3"
+
+        # Paddle Version
+        self.paddle_version = paddle.__version__
+        self.paddle_commit = paddle.__git_commit__
+        paddle_infer_info = paddle_infer.get_version()
+        self.paddle_branch = paddle_infer_info.strip().split(': ')[-1]
+
+        # model info
+        self.model_info = model_info
+
+        # data info
+        self.data_info = data_info
+
+        # perf info
+        self.perf_info = perf_info
+
+        try:
+            # required value
+            self.model_name = model_info['model_name']
+            self.precision = model_info['precision']
+
+            self.batch_size = data_info['batch_size']
+            self.shape = data_info['shape']
+            self.data_num = data_info['data_num']
+
+            self.inference_time_s = round(perf_info['inference_time_s'], 4)
+        except:
+            self.print_help()
+            raise ValueError(
+                "Set argument wrong, please check input argument and its type")
+
+        self.preprocess_time_s = perf_info.get('preprocess_time_s', 0)
+        self.postprocess_time_s = perf_info.get('postprocess_time_s', 0)
+        self.total_time_s = perf_info.get('total_time_s', 0)
+
+        self.inference_time_s_90 = perf_info.get("inference_time_s_90", "")
+        self.inference_time_s_99 = perf_info.get("inference_time_s_99", "")
+        self.succ_rate = perf_info.get("succ_rate", "")
+        self.qps = perf_info.get("qps", "")
+
+        # conf info
+        self.config_status = self.parse_config(config)
+
+        # mem info
+        if isinstance(resource_info, dict):
+            self.cpu_rss_mb = int(resource_info.get('cpu_rss_mb', 0))
+            self.cpu_vms_mb = int(resource_info.get('cpu_vms_mb', 0))
+            self.cpu_shared_mb = int(resource_info.get('cpu_shared_mb', 0))
+            self.cpu_dirty_mb = int(resource_info.get('cpu_dirty_mb', 0))
+            self.cpu_util = round(resource_info.get('cpu_util', 0), 2)
+
+            self.gpu_rss_mb = int(resource_info.get('gpu_rss_mb', 0))
+            self.gpu_util = round(resource_info.get('gpu_util', 0), 2)
+            self.gpu_mem_util = round(resource_info.get('gpu_mem_util', 0), 2)
+        else:
+            self.cpu_rss_mb = 0
+            self.cpu_vms_mb = 0
+            self.cpu_shared_mb = 0
+            self.cpu_dirty_mb = 0
+            self.cpu_util = 0
+
+            self.gpu_rss_mb = 0
+            self.gpu_util = 0
+            self.gpu_mem_util = 0
+
+        # init benchmark logger
+        self.benchmark_logger()
+
+    def benchmark_logger(self):
+        """
+        benchmark logger
+        """
+        # remove other logging handler
+        for handler in logging.root.handlers[:]:
+            logging.root.removeHandler(handler)
+
+        # Init logger
+        FORMAT = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        log_output = f"{LOG_PATH_ROOT}/{self.model_name}.log"
+        Path(f"{LOG_PATH_ROOT}").mkdir(parents=True, exist_ok=True)
+        logging.basicConfig(
+            level=logging.INFO,
+            format=FORMAT,
+            handlers=[
+                logging.FileHandler(filename=log_output, mode='w'),
+                logging.StreamHandler(),
+            ])
+        self.logger = logging.getLogger(__name__)
+        self.logger.info(
+            f"Paddle Inference benchmark log will be saved to {log_output}")
+
+    def parse_config(self, config) -> dict:
+        """
+        parse paddle predictor config
+        args:
+            config(paddle.inference.Config): paddle inference config
+        return:
+            config_status(dict): dict style config info
+        """
+        if isinstance(config, paddle_infer.Config):
+            config_status = {}
+            config_status['runtime_device'] = "gpu" if config.use_gpu(
+            ) else "cpu"
+            config_status['ir_optim'] = config.ir_optim()
+            config_status['enable_tensorrt'] = config.tensorrt_engine_enabled()
+            config_status['precision'] = self.precision
+            config_status['enable_mkldnn'] = config.mkldnn_enabled()
+            config_status[
+                'cpu_math_library_num_threads'] = config.cpu_math_library_num_threads(
+                )
+        elif isinstance(config, dict):
+            config_status['runtime_device'] = config.get('runtime_device', "")
+            config_status['ir_optim'] = config.get('ir_optim', "")
+            config_status['enable_tensorrt'] = config.get('enable_tensorrt', "")
+            config_status['precision'] = config.get('precision', "")
+            config_status['enable_mkldnn'] = config.get('enable_mkldnn', "")
+            config_status['cpu_math_library_num_threads'] = config.get(
+                'cpu_math_library_num_threads', "")
+        else:
+            self.print_help()
+            raise ValueError(
+                "Set argument config wrong, please check input argument and its type"
+            )
+        return config_status
+
+    def report(self, identifier=None):
+        """
+        print log report
+        args:
+            identifier(string): identify log
+        """
+        if identifier:
+            identifier = f"[{identifier}]"
+        else:
+            identifier = ""
+
+        self.logger.info("\n")
+        self.logger.info(
+            "---------------------- Paddle info ----------------------")
+        self.logger.info(f"{identifier} paddle_version: {self.paddle_version}")
+        self.logger.info(f"{identifier} paddle_commit: {self.paddle_commit}")
+        self.logger.info(f"{identifier} paddle_branch: {self.paddle_branch}")
+        self.logger.info(f"{identifier} log_api_version: {self.log_version}")
+        self.logger.info(
+            "----------------------- Conf info -----------------------")
+        self.logger.info(
+            f"{identifier} runtime_device: {self.config_status['runtime_device']}"
+        )
+        self.logger.info(
+            f"{identifier} ir_optim: {self.config_status['ir_optim']}")
+        self.logger.info(f"{identifier} enable_memory_optim: {True}")
+        self.logger.info(
+            f"{identifier} enable_tensorrt: {self.config_status['enable_tensorrt']}"
+        )
+        self.logger.info(
+            f"{identifier} enable_mkldnn: {self.config_status['enable_mkldnn']}"
+        )
+        self.logger.info(
+            f"{identifier} cpu_math_library_num_threads: {self.config_status['cpu_math_library_num_threads']}"
+        )
+        self.logger.info(
+            "----------------------- Model info ----------------------")
+        self.logger.info(f"{identifier} model_name: {self.model_name}")
+        self.logger.info(f"{identifier} precision: {self.precision}")
+        self.logger.info(
+            "----------------------- Data info -----------------------")
+        self.logger.info(f"{identifier} batch_size: {self.batch_size}")
+        self.logger.info(f"{identifier} input_shape: {self.shape}")
+        self.logger.info(f"{identifier} data_num: {self.data_num}")
+        self.logger.info(
+            "----------------------- Perf info -----------------------")
+        self.logger.info(
+            f"{identifier} cpu_rss(MB): {self.cpu_rss_mb}, cpu_vms: {self.cpu_vms_mb}, cpu_shared_mb: {self.cpu_shared_mb}, cpu_dirty_mb: {self.cpu_dirty_mb}, cpu_util: {self.cpu_util}%"
+        )
+        self.logger.info(
+            f"{identifier} gpu_rss(MB): {self.gpu_rss_mb}, gpu_util: {self.gpu_util}%, gpu_mem_util: {self.gpu_mem_util}%"
+        )
+        self.logger.info(
+            f"{identifier} total time spent(s): {self.total_time_s}")
+        self.logger.info(
+            f"{identifier} preprocess_time(ms): {round(self.preprocess_time_s*1000, 1)}, inference_time(ms): {round(self.inference_time_s*1000, 1)}, postprocess_time(ms): {round(self.postprocess_time_s*1000, 1)}"
+        )
+        if self.inference_time_s_90:
+            self.logger.info(
+                f"{identifier} 90%_cost: {self.inference_time_s_90}, 99%_cost: {self.inference_time_s_99}, succ_rate: {self.succ_rate}"
+            )
+        if self.qps:
+            self.logger.info(f"{identifier} QPS: {self.qps}")
+
+    def print_help(self):
+        """
+        print function help
+        """
+        print("""Usage:
+            ==== Print inference benchmark logs. ====
+            config = paddle.inference.Config()
+            model_info = {'model_name': 'resnet50'
+                          'precision': 'fp32'}
+            data_info = {'batch_size': 1
+                         'shape': '3,224,224'
+                         'data_num': 1000}
+            perf_info = {'preprocess_time_s': 1.0
+                         'inference_time_s': 2.0
+                         'postprocess_time_s': 1.0
+                         'total_time_s': 4.0}
+            resource_info = {'cpu_rss_mb': 100
+                             'gpu_rss_mb': 100
+                             'gpu_util': 60}
+            log = PaddleInferBenchmark(config, model_info, data_info, perf_info, resource_info)
+            log('Test')
+            """)
+
+    def __call__(self, identifier=None):
+        """
+        __call__
+        args:
+            identifier(string): identify log
+        """
+        self.report(identifier)

--- a/tools/infer/predict.py
+++ b/tools/infer/predict.py
@@ -1,0 +1,385 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import codecs
+import os
+import time
+import sys
+
+import pynvml
+import psutil
+import GPUtil
+import yaml
+import numpy as np
+sys.path.append(os.path.abspath(os.path.join(os.getcwd(), "../..")))
+import paddleseg.transforms as T
+from paddle.inference import create_predictor, PrecisionType
+from paddle.inference import Config as PredictConfig
+from paddleseg.cvlibs import manager
+from paddleseg.utils import get_sys_env, logger
+from paddleseg.utils.visualize import get_pseudo_color_map
+from benchmark_utils import PaddleInferBenchmark
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Model training')
+    # params of training
+    parser.add_argument(
+        "--config",
+        dest="cfg",
+        help="The config file.",
+        default=None,
+        type=str,
+        required=True)
+    parser.add_argument(
+        '--data_dir',
+        dest='data_dir',
+        help='The directory or path of the image to be predicted.',
+        type=str,
+        default=None,
+        required=True)
+    parser.add_argument(
+        '--file_path',
+        dest='file_path',
+        help='The directory or path of the image to be predicted.',
+        type=str,
+        default=None,
+        required=True)
+    parser.add_argument(
+        '--batch_size',
+        dest='batch_size',
+        help='Mini batch size of one gpu or cpu.',
+        type=int,
+        default=1)
+    parser.add_argument(
+        '--save_dir',
+        dest='save_dir',
+        help='The directory for saving the predict result.',
+        type=str,
+        default='./output')
+    parser.add_argument(
+        '--without_argmax',
+        dest='without_argmax',
+        help='Do not perform argmax operation on the predict result.',
+        action='store_true')
+
+    def str2bool(v):
+        return v.lower() in ("true", "t", "1")
+
+    # params for prediction engine
+    parser.add_argument("--device", type=str, default='gpu')
+    parser.add_argument("--cpu_threads", type=int, default=6)
+    parser.add_argument("--enable_mkldnn", type=str2bool, default=False)
+    parser.add_argument(
+        '--use_trt',
+        dest='use_trt',
+        help='Whether to use Nvidia TensorRT to accelerate prediction.',
+        type=str2bool,
+        default=False)
+    parser.add_argument(
+        '--precision',
+        help='precision when using TensorRT prediction.',
+        type=str,
+        default='fp32',
+        choices=['fp32', 'fp16', 'int8'])
+    return parser.parse_args()
+
+
+class DeployConfig:
+    def __init__(self, path):
+        with codecs.open(path, 'r', 'utf-8') as file:
+            self.dic = yaml.load(file, Loader=yaml.FullLoader)
+
+        self._transforms = self._load_transforms(
+            self.dic['Deploy']['transforms'])
+        self._dir = os.path.dirname(path)
+
+    @property
+    def transforms(self):
+        return self._transforms
+
+    @property
+    def model(self):
+        return os.path.join(self._dir, self.dic['Deploy']['model'])
+
+    @property
+    def params(self):
+        return os.path.join(self._dir, self.dic['Deploy']['params'])
+
+    def _load_transforms(self, t_list):
+        com = manager.TRANSFORMS
+        transforms = []
+        for t in t_list:
+            ctype = t.pop('type')
+            transforms.append(com[ctype](**t))
+
+        return T.Compose(transforms)
+
+
+class Predictor:
+    def __init__(self, args):
+        self.cfg = DeployConfig(args.cfg)
+        self.args = args
+
+        pred_cfg = PredictConfig(self.cfg.model, self.cfg.params)
+        # pred_cfg.disable_glog_info()
+        if self.args.device == 'gpu':
+            pred_cfg.enable_use_gpu(100, 0)
+
+            if self.args.use_trt:
+                if args.precision == "fp32":
+                    ptype = PrecisionType.Float32
+                elif args.precision == "fp16":
+                    ptype = PrecisionType.Half
+                elif args.precision == "int8":
+                    ptype = PrecisionType.Int8
+                else:
+                    raise ValueError(
+                        "argument precision set wrong, it can only be fp32, fp16 and int8"
+                    )
+
+                pred_cfg.enable_tensorrt_engine(
+                    workspace_size=1 << 30,
+                    max_batch_size=1,
+                    min_subgraph_size=3,
+                    precision_mode=ptype,
+                    use_static=False,
+                    use_calib_mode=False)
+                min_input_shape = {
+                    "x": [1, 3, 100, 100],
+                    "bilinear_interp_v2_0.tmp_0": [1, 16, 25, 25],
+                    "relu_10.tmp_0": [1, 16, 25, 25],
+                    "relu_25.tmp_0": [1, 32, 13, 13],
+                    "batch_norm_37.tmp_2": [1, 64, 7, 7],
+                    "bilinear_interp_v2_1.tmp_0": [1, 16, 25, 25],
+                    "bilinear_interp_v2_2.tmp_0": [1, 16, 25, 25],
+                    "bilinear_interp_v2_3.tmp_0": [1, 32, 13, 13],
+                    "relu_21.tmp_0": [1, 16, 25, 25],
+                    "relu_29.tmp_0": [1, 64, 7, 7],
+                    "relu_32.tmp_0": [1, 16, 13, 13],
+                    "tmp_15": [1, 32, 13, 13]
+                }
+                max_input_shape = {
+                    "x": [1, 3, 2000, 2000],
+                    "bilinear_interp_v2_0.tmp_0": [1, 16, 500, 500],
+                    "relu_10.tmp_0": [1, 16, 500, 500],
+                    "relu_25.tmp_0": [1, 32, 250, 250],
+                    "batch_norm_37.tmp_2": [1, 64, 125, 125],
+                    "bilinear_interp_v2_1.tmp_0": [1, 16, 500, 500],
+                    "bilinear_interp_v2_2.tmp_0": [1, 16, 500, 500],
+                    "bilinear_interp_v2_3.tmp_0": [1, 32, 250, 250],
+                    "relu_21.tmp_0": [1, 16, 500, 500],
+                    "relu_29.tmp_0": [1, 64, 125, 125],
+                    "relu_32.tmp_0": [1, 16, 250, 250],
+                    "tmp_15": [1, 32, 250, 250]
+                }
+                opt_input_shape = {
+                    "x": [1, 3, 192, 192],
+                    "bilinear_interp_v2_0.tmp_0": [1, 16, 48, 48],
+                    "relu_10.tmp_0": [1, 16, 48, 48],
+                    "relu_25.tmp_0": [1, 32, 24, 24],
+                    "batch_norm_37.tmp_2": [1, 64, 12, 12],
+                    "bilinear_interp_v2_1.tmp_0": [1, 16, 48, 48],
+                    "bilinear_interp_v2_2.tmp_0": [1, 16, 48, 48],
+                    "bilinear_interp_v2_3.tmp_0": [1, 32, 24, 24],
+                    "relu_21.tmp_0": [1, 16, 48, 48],
+                    "relu_29.tmp_0": [1, 64, 12, 12],
+                    "relu_32.tmp_0": [1, 16, 24, 24],
+                    "tmp_15": [1, 32, 24, 24]
+                }
+                pred_cfg.set_trt_dynamic_shape_info(
+                    min_input_shape, max_input_shape, opt_input_shape)
+        else:
+            pred_cfg.disable_gpu()
+            pred_cfg.set_cpu_math_library_num_threads(args.cpu_threads)
+            if args.enable_mkldnn:
+                # cache 10 different shapes for mkldnn to avoid memory leak
+                pred_cfg.set_mkldnn_cache_capacity(10)
+                pred_cfg.enable_mkldnn()
+
+        # enable memory optim
+        pred_cfg.enable_memory_optim()
+
+        self.predictor = create_predictor(pred_cfg)
+        self.config = pred_cfg
+
+    def preprocess(self, img):
+        return self.cfg.transforms(img)[0]
+
+    def run(self, imgs):
+        if not isinstance(imgs, (list, tuple)):
+            imgs = [imgs]
+
+        self.num = len(imgs)
+        input_names = self.predictor.get_input_names()
+        input_handle = self.predictor.get_input_handle(input_names[0])
+        results = []
+
+        self.preprocess_time = Times()
+        self.inference_time = Times()
+        self.postprocess_time = Times()
+        cpu_mem, gpu_mem = 0, 0
+        gpu_id = 0
+        gpu_util = 0
+
+        iter_ = 0
+
+        for i in range(0, self.num, self.args.batch_size):
+            self.preprocess_time.start()
+            data = np.array([
+                self.preprocess(img) for img in imgs[i:i + self.args.batch_size]
+            ])
+            self.preprocess_time.end()
+
+            # inference
+            self.inference_time.start()
+            input_handle.reshape(data.shape)
+            input_handle.copy_from_cpu(data)
+            self.predictor.run()
+            output_names = self.predictor.get_output_names()
+            output_handle = self.predictor.get_output_handle(output_names[0])
+            results.append(output_handle.copy_to_cpu())
+            self.inference_time.end()
+
+            gpu_util += get_current_gputil(gpu_id)
+            cm, gm = get_current_memory_mb(gpu_id)
+            cpu_mem += cm
+            gpu_mem += gm
+
+            iter_ += 1
+
+        self.postprocess_time.start()
+        self.postprocess(results, imgs)
+        self.postprocess_time.end()
+        self.avg_preprocess = self.preprocess_time.value() / self.num
+        self.avg_inference = self.inference_time.value() / self.num
+        self.avg_postprocess = self.postprocess_time.value() / self.num
+        self.avg_cpu_mem = cpu_mem / iter_
+        self.avg_gpu_mem = gpu_mem / iter_
+        self.avg_gpu_util = gpu_util / iter_
+
+    def postprocess(self, results, imgs):
+        if not os.path.exists(self.args.save_dir):
+            os.makedirs(self.args.save_dir)
+
+        results = np.concatenate(results, axis=0)
+        for i in range(results.shape[0]):
+            if self.args.without_argmax:
+                result = results[i]
+            else:
+                result = np.argmax(results[i], axis=0)
+            result = get_pseudo_color_map(result)
+            basename = os.path.basename(imgs[i])
+            basename, _ = os.path.splitext(basename)
+            basename = f'{basename}.png'
+            result.save(os.path.join(self.args.save_dir, basename))
+
+    def report(self):
+        perf_info = {
+            'inference_time_s': self.avg_inference,
+            'preprocess_time_s': self.avg_preprocess,
+            'postprocess_time_s': self.avg_postprocess
+        }
+        model_info = {
+            'model_name': self.args.cfg.split('/')[-2],
+            'precision': self.args.precision
+        }
+        data_info = {
+            'batch_size': self.args.batch_size,
+            'shape': "dynamic_shape",
+            'data_num': self.num
+        }
+        resource_info = {
+            'cpu_rss_mb': self.avg_cpu_mem,
+            'gpu_rss_mb': self.avg_gpu_mem,
+            'gpu_util': self.avg_gpu_util
+        }
+        seg_log = PaddleInferBenchmark(self.config, model_info, data_info,
+                                       perf_info, resource_info)
+        seg_log('Seg')
+
+
+# create time count class
+class Times(object):
+    def __init__(self):
+        self.time = 0.
+        self.st = 0.
+        self.et = 0.
+
+    def start(self):
+        self.st = time.time()
+
+    def end(self, accumulative=True):
+        self.et = time.time()
+        if accumulative:
+            self.time += self.et - self.st
+        else:
+            self.time = self.et - self.st
+
+    def reset(self):
+        self.time = 0.
+        self.st = 0.
+        self.et = 0.
+
+    def value(self):
+        return round(self.time, 4)
+
+
+def get_current_memory_mb(gpu_id=None):
+    pid = os.getpid()
+    p = psutil.Process(pid)
+    info = p.memory_full_info()
+    cpu_mem = info.uss / 1024. / 1024.
+    gpu_mem = 0
+    if gpu_id is not None:
+        pynvml.nvmlInit()
+        handle = pynvml.nvmlDeviceGetHandleByIndex(0)
+        meminfo = pynvml.nvmlDeviceGetMemoryInfo(handle)
+        gpu_mem = meminfo.used / 1024. / 1024.
+    return cpu_mem, gpu_mem
+
+
+def get_current_gputil(gpu_id):
+    GPUs = GPUtil.getGPUs()
+    gpu_load = GPUs[gpu_id].load
+    return gpu_load
+
+
+def get_images(file_path, data_dir):
+    img_list = []
+    with open(file_path, 'r') as f:
+        lines = f.readlines()
+        for idx, line in enumerate(lines):
+            img_path, label = line.split()
+            img_path = os.path.join(data_dir, img_path)
+            img_list.append(img_path)
+    return img_list
+
+
+def main(args):
+    env_info = get_sys_env()
+    info = ['{}: {}'.format(k, v) for k, v in env_info.items()]
+    info = '\n'.join(['', format('Environment Information', '-^48s')] + info +
+                     ['-' * 48])
+    print(info)
+
+    predictor = Predictor(args)
+    predictor.run(get_images(args.file_path, args.data_dir))
+    predictor.report()
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    main(args)


### PR DESCRIPTION
修改PaddleSeg的预测日志格式
代码内容与 [PaddleClas #730](https://github.com/PaddlePaddle/PaddleClas/pull/730) ，[PaddleDetection #3054](https://github.com/PaddlePaddle/PaddleDetection/pull/3054) 一致

日志输出路径为 PaddleSeg/output/*.log

输出到终端和日志文件的样式
```shell
2021-05-24 07:19:06,016 - benchmark_utils - INFO - Paddle Inference benchmark log will be saved to /workspace/tools/infer/../../output/fcn_hrnetw18_small_v1_not_fix_shape_argmax_humanseg_192x192_bs64_lr0.1_iter2w_horizontal_distort.log
2021-05-24 07:19:06,016 - benchmark_utils - INFO -

2021-05-24 07:19:06,016 - benchmark_utils - INFO - ---------------------- Paddle info ----------------------
2021-05-24 07:19:06,016 - benchmark_utils - INFO - [Seg] paddle_version: 0.0.0
2021-05-24 07:19:06,016 - benchmark_utils - INFO - [Seg] paddle_commit: 70e0e3d53f7375bd17fb8b9dd6ba0802990800ae
2021-05-24 07:19:06,016 - benchmark_utils - INFO - [Seg] paddle_branch: release/2.1
2021-05-24 07:19:06,016 - benchmark_utils - INFO - [Seg] log_api_version: 1.0.3
2021-05-24 07:19:06,016 - benchmark_utils - INFO - ----------------------- Conf info -----------------------
2021-05-24 07:19:06,016 - benchmark_utils - INFO - [Seg] runtime_device: gpu
2021-05-24 07:19:06,017 - benchmark_utils - INFO - [Seg] ir_optim: True
2021-05-24 07:19:06,017 - benchmark_utils - INFO - [Seg] enable_memory_optim: True
2021-05-24 07:19:06,017 - benchmark_utils - INFO - [Seg] enable_tensorrt: False
2021-05-24 07:19:06,017 - benchmark_utils - INFO - [Seg] enable_mkldnn: False
2021-05-24 07:19:06,017 - benchmark_utils - INFO - [Seg] cpu_math_library_num_threads: 1
2021-05-24 07:19:06,017 - benchmark_utils - INFO - ----------------------- Model info ----------------------
2021-05-24 07:19:06,017 - benchmark_utils - INFO - [Seg] model_name: fcn_hrnetw18_small_v1_not_fix_shape_argmax_humanseg_192x192_bs64_lr0.1_iter2w_horizontal_distort
2021-05-24 07:19:06,017 - benchmark_utils - INFO - [Seg] precision: fp32
2021-05-24 07:19:06,017 - benchmark_utils - INFO - ----------------------- Data info -----------------------
2021-05-24 07:19:06,017 - benchmark_utils - INFO - [Seg] batch_size: 1
2021-05-24 07:19:06,017 - benchmark_utils - INFO - [Seg] input_shape: dynamic_shape
2021-05-24 07:19:06,017 - benchmark_utils - INFO - [Seg] data_num: 100
2021-05-24 07:19:06,018 - benchmark_utils - INFO - ----------------------- Perf info -----------------------
2021-05-24 07:19:06,018 - benchmark_utils - INFO - [Seg] cpu_rss(MB): 2192, cpu_vms: 0, cpu_shared_mb: 0, cpu_dirty_mb: 0, cpu_util: 0%
2021-05-24 07:19:06,018 - benchmark_utils - INFO - [Seg] gpu_rss(MB): 579, gpu_util: 0.03%, gpu_mem_util: 0%
2021-05-24 07:19:06,018 - benchmark_utils - INFO - [Seg] total time spent(s): 0
2021-05-24 07:19:06,018 - benchmark_utils - INFO - [Seg] preprocess_time(ms): 31.2, inference_time(ms): 27.1, postprocess_time(ms): 1.8
```