### PR TITLE
Fixed save path for predictive script output under Windows

### DIFF
--- a/paddleseg/core/predict.py
+++ b/paddleseg/core/predict.py
@@ -121,7 +121,7 @@ def predict(model,
                 im_file = im_path.replace(image_dir, '')
             else:
                 im_file = os.path.basename(im_path)
-            if im_file[0] == '/':
+            if im_file[0] == '/' or im_file[0] == '\\':
                 im_file = im_file[1:]
 
             # save added image


### PR DESCRIPTION
修复Windows下，预测脚本输出保存路径的问题
未修改时，在Windows运行predict.py，输出结果会直接保存到根目录，例如原本输入的保存路径为D:\\output，则会直接保存在D:\\下