### PR TITLE
In fix 2.1.0, evaluate has five return values, whereas line 86 of paddleseg/slim/prune.py receives only two

### DIFF
--- a/slim/prune.py
+++ b/slim/prune.py
@@ -82,7 +82,7 @@ def parse_args():
 
 
 def eval_fn(net, eval_dataset, num_workers):
-    miou, _ = evaluate(
+    miou, _, _, _, _ = evaluate(
         net, eval_dataset, num_workers=num_workers, print_detail=False)
     return miou
 


### PR DESCRIPTION
修复2.1.0中，evaluate有五个返回值，而paddleseg/slim/prune.py 第86行处仅接收了两个返回值