### PR TITLE
optimize inference post-process

### DIFF
--- a/paddleseg/core/infer.py
+++ b/paddleseg/core/infer.py
@@ -222,8 +222,8 @@ def inference(model,
     else:
         logit = slide_inference(model, im, crop_size=crop_size, stride=stride)
     if ori_shape is not None:
-        pred = paddle.argmax(logit, axis=1, keepdim=True, dtype='int32')
-        pred = reverse_transform(pred, ori_shape, transforms)
+        pred = reverse_transform(logit, ori_shape, transforms, mode='bilinear')
+        pred = paddle.argmax(pred, axis=1, keepdim=True, dtype='int32')
         return pred
     else:
         return logit
@@ -284,6 +284,7 @@ def aug_inference(model,
             logit = F.softmax(logit, axis=1)
             final_logit = final_logit + logit
 
-    pred = paddle.argmax(final_logit, axis=1, keepdim=True, dtype='int32')
-    pred = reverse_transform(pred, ori_shape, transforms)
+    pred = reverse_transform(
+        final_logit, ori_shape, transforms, mode='bilinear')
+    pred = paddle.argmax(pred, axis=1, keepdim=True, dtype='int32')
     return pred


### PR DESCRIPTION
Optimize the post-processing of inference to **improve the inference accuracy** and **eliminate jagged edges**.

**mIoU from 93.11 up to 93.29**

Before optimizing:
![image](https://user-images.githubusercontent.com/30695251/121669048-8225d500-cade-11eb-8b33-64bfb3400d02.png)

After optimizing:
![image](https://user-images.githubusercontent.com/30695251/121669107-923db480-cade-11eb-94c1-318648063ea3.png)

Solve #1080 