### PR TITLE
remove invalid escape sequence warnings when import paddleseg

### DIFF
--- a/paddleseg/cvlibs/param_init.py
+++ b/paddleseg/cvlibs/param_init.py
@@ -58,7 +58,7 @@ def normal_init(param, **kwargs):
 
 
 def kaiming_normal_init(param, **kwargs):
-    """
+    r"""
     Initialize the input tensor with Kaiming Normal initialization.
 
     This function implements the `param` initialization from the paper

--- a/paddleseg/models/losses/binary_cross_entropy_loss.py
+++ b/paddleseg/models/losses/binary_cross_entropy_loss.py
@@ -21,7 +21,7 @@ from paddleseg.cvlibs import manager
 
 @manager.LOSSES.add_component
 class BCELoss(nn.Layer):
-    """
+    r"""
     This operator combines the sigmoid layer and the :ref:`api_nn_loss_BCELoss` layer.
     Also, we can see it as the combine of ``sigmoid_cross_entropy_with_logits``
     layer and some reduce operations.

--- a/paddleseg/models/losses/lovasz_loss.py
+++ b/paddleseg/models/losses/lovasz_loss.py
@@ -41,7 +41,7 @@ class LovaszSoftmaxLoss(nn.Layer):
         self.classes = classes
 
     def forward(self, logits, labels):
-        """
+        r"""
         Forward computation.
 
         Args:
@@ -68,7 +68,7 @@ class LovaszHingeLoss(nn.Layer):
         self.ignore_index = ignore_index
 
     def forward(self, logits, labels):
-        """
+        r"""
         Forward computation.
 
         Args:
@@ -111,7 +111,7 @@ def binary_channel_to_unary(logits, eps=1e-9):
 
 
 def lovasz_hinge_flat(logits, labels):
-    """
+    r"""
     Binary Lovasz hinge loss.
 
     Args:


### PR DESCRIPTION
Fix the following problem 
<img width="1892" alt="33bce6265d444d535ca81556a999d447" src="https://user-images.githubusercontent.com/30695251/122868230-44863f00-d35d-11eb-9c90-d18f9c10fd36.png">
Now
![image](https://user-images.githubusercontent.com/30695251/122868432-8616ea00-d35d-11eb-90c9-1cd51eda0837.png)
