### PR TITLE
fix multi-process dataloader with same random seeds during epochs

### DIFF
--- a/paddleseg/utils/utils.py
+++ b/paddleseg/utils/utils.py
@@ -14,10 +14,10 @@
 
 import contextlib
 import filelock
-import math
 import os
 import tempfile
 import numpy as np
+import random
 from urllib.parse import urlparse, unquote
 
 import paddle
@@ -122,4 +122,4 @@ def resume(model, optimizer, resume_model):
 
 
 def worker_init_fn(worker_id):
-    np.random.seed(np.random.get_state()[1][0] + worker_id)
+    np.random.seed(random.randint(0, 100000))


### PR DESCRIPTION
Continue to optimize for https://github.com/PaddlePaddle/PaddleSeg/pull/1078
following https://tanelp.github.io/posts/a-bug-that-plagues-thousands-of-open-source-ml-projects/

# test code:
before
```
import numpy as np
import paddle
import random

class RandomDataset(paddle.io.Dataset):
    def __getitem__(self, index):
        return np.random.randint(0, 1000, 2)

    def __len__(self):
        return 8


dataset = RandomDataset()

def worker_init_fn(worker_id):
    seed = np.random.get_state()[1][0] + worker_id
    print(seed)
    np.random.seed(seed)

dataloader = paddle.io.DataLoader(dataset, batch_size=2, num_workers=2, worker_init_fn=worker_init_fn)
for i in range(2):
    print('epoch', i)
    for batch in dataloader:
        print(batch)
    print()
```
![image](https://user-images.githubusercontent.com/30695251/124077138-b9eac180-da79-11eb-9409-2bf0279cc7e2.png)


Now
```
dataset = RandomDataset()

def worker_init_fn(worker_id):
    seed = random.randint(0, 100000)
    print(seed)
    np.random.seed(seed)

dataloader = paddle.io.DataLoader(dataset, batch_size=2, num_workers=2, worker_init_fn=worker_init_fn)
for i in range(2):
    print('epoch', i)
    for batch in dataloader:
        random.seed(100)
        print(batch)
    print()
```
![image](https://user-images.githubusercontent.com/30695251/124076477-e05c2d00-da78-11eb-984e-f4bf94c599c6.png)
