### PR TITLE
Fix OOM in slim pruning

### DIFF
--- a/slim/prune.py
+++ b/slim/prune.py
@@ -149,7 +149,7 @@ def main(args):
 
     logger.info(
         'Step 1/3: Start calculating the sensitivity of model parameters...')
-    sample_shape = [1] + list(val_dataset[0][0].shape)
+    sample_shape = [1] + list(train_dataset[0][0].shape)
     sen_file = os.path.join(args.save_dir, 'sen.pickle')
     pruner = L1NormFilterPruner(net, sample_shape)
     pruner.sensitive(


### PR DESCRIPTION

## 问题

v100-16G环境下执行以下脚本，报OOM错误：

```
python slim/prune.py \
    --config configs/attention_unet/attention_unet_cityscapes_1024x512_80k.yml \
    --batch_size 1 \
    --retraining_iters 10 --pruning_ratio 0.5 --save_dir prune_model/attention_unet/ 
```


## 修复

修改PaddleSeg repo中的slim/prune.py文件，将

```
sample_shape = [1] + list(val_dataset[0][0].shape)
```

修改为：

```
sample_shape = [1] + list(train_dataset[0][0].shape)
```

https://github.com/PaddlePaddle/PaddleSeg/blob/develop/slim/prune.py#L152

已验证该修复之后，模型训练显存占用不会超过16G.



原因：

在构造L1NormFilterPruner实例时，会根据sample_shape执行一遍动态图的前向计算，以便将动态图转成静态图，该过程占用的显存与sample_shape正相关。动态图转成静态图是为了分析模型结构，所用的sample_shape不会影响分析的准确性，所以要尽量使用小的sample_shape.

以CityScape数据为例，```train_dataset```的shape为 (3, 512, 1024)，```val_dataset```的shape为(3, 1024, 2048) ；