### PR TITLE
enable_memory_optim and switch_ir_optim for deploy/python/infer.py

### DIFF
--- a/deploy/python/infer.py
+++ b/deploy/python/infer.py
@@ -64,8 +64,10 @@ class Predictor:
 
         pred_cfg = PredictConfig(self.cfg.model, self.cfg.params)
         pred_cfg.disable_glog_info()
+        pred_cfg.enable_memory_optim()
         if self.args.use_gpu:
             pred_cfg.enable_use_gpu(100, 0)
+            pred_cfg.switch_ir_optim(True)
 
             if self.args.use_trt:
                 ptype = PrecisionType.Int8 if args.use_int8 else PrecisionType.Float32


### PR DESCRIPTION
The used gpu memory is so large that a 2560x1920 image data cannot be inferred on a 16160MiB gpu card, so we set enable_memory_optim and switch_ir_optim when initializing a predictor.

Before adding these setting:
![image](https://user-images.githubusercontent.com/22235422/126292816-c8d5f518-2952-4a4f-8b6e-9820a0aada27.png)

After adding these setting:
![image](https://user-images.githubusercontent.com/22235422/126292890-2457ab26-cecf-495b-84b2-63d849908fc8.png)

