### PR TITLE
Add inference timer.

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -96,7 +96,7 @@ PaddleSeg是基于飞桨[PaddlePaddle](https://www.paddlepaddle.org.cn)开发的
 * [模型导出](./docs/export/export/model_export.md)
 
 *  模型部署
-    * [Inference](./docs/deployment/inference/inference.md)
+    * [Inference](./docs/deployment/inference/inference_cn.md)
     * [Lite](./docs/deployment/lite/lite.md)
     * [Serving](./docs/deployment/serving/serving.md)
     * [Web](./docs/deployment/web/web.md)

--- a/deploy/python/README.md
+++ b/deploy/python/README.md
@@ -1,36 +1,68 @@
-# PaddleSeg Python 预测部署方案
+English | [简体中文](README_CN.md)
+# Local inference deployment
 
-## 1. 说明
+## 1. Instruction
 
-本方案旨在提供一个PaddlePaddle跨平台图像分割模型的Python预测部署方案作为参考，用户通过一定的配置，加上少量的代码，即可把模型集成到自己的服务中，完成图像分割的任务。
+This solution aims to provide a Python prediction deployment solution for the PaddlePaddle cross-platform image segmentation model as a reference. Users can integrate the model into their own services through a certain configuration and add a small amount of code to complete the task of image segmentation.
 
-## 2. 前置准备
 
-请使用[模型导出工具](../../docs/model_export.md)导出您的模型, 或点击下载我们的[样例模型](https://paddleseg.bj.bcebos.com/dygraph/demo/bisenet_demo_model.tar.gz)用于测试。
+## 2. Pre-preparation
 
-接着准备一张测试图片用于试验效果，我们提供了cityscapes验证集中的一张[图片](https://paddleseg.bj.bcebos.com/dygraph/demo/cityscapes_demo.png)用于演示效果，如果您的模型是使用其他数据集训练的，请自行准备测试图片。
+Please refer to [document](../../export/export/model_export.md) to export your model, or click to download our [sample model](https://paddleseg.bj.bcebos.com/dygraph/demo/bisenet_demo_model.tar.gz) is used for testing.
 
-## 3. 预测
+Then prepare a picture for the test effect, we provide a [picture] (https://paddleseg.bj.bcebos.com/dygraph/demo/cityscapes_demo.png) in the cityscapes verification set to see the effect, if your model is trained by other data sets, please prepare test images by yourself.
 
-在终端输入以下命令进行预测:
+
+## 3. Prediction
+
+Enter the following command in the terminal to make predictions:
 ```shell
 python deploy/python/infer.py --config /path/to/deploy.yaml --image_path
 ```
 
-参数说明如下:
-|参数名|用途|是否必选项|默认值|
+Parameters:
+|Parameter|Effection|Is required|Default|
 |-|-|-|-|
-|config|**导出模型时生成的配置文件**, 而非configs目录下的配置文件|是|-|
-|image_path|预测图片的路径或者目录|是|-|
-|use_trt|是否开启TensorRT来加速预测|否|否|
-|use_int8|启动TensorRT预测时，是否以int8模式运行|否|否|
-|batch_size|单卡batch size|否|配置文件中指定值|
-|save_dir|保存预测结果的目录|否|output|
-|with_argmax|对预测结果进行argmax操作|否|否|
+|config|**Configuration file generated when exporting the model**, instead of the configuration file in the configs directory|Yes|-|
+|image_path|The path or directory of the test image.|Yes|-|
+|use_trt|Whether to enable TensorRT to accelerate prediction.|No|No|
+|use_int8|Whether to run in int8 mode when starting TensorRT prediction.|No|No|
+|batch_size|Batch sizein single card.|No|The value specified in the configuration file.|
+|save_dir|The directory of prediction results.|No|output|
+|with_argmax|Perform argmax operation on the prediction results.|No|No|
 
-*测试样例和预测结果如下*
-![cityscape_predict_demo.png](../../docs/images/cityscapes_predict_demo.png)
+*The test sample and prediction result*
+![cityscape_predict_demo.png](../../../docs/images/cityscapes_predict_demo.png)
 
-*注意：*
-*1. 当使用量化模型预测时，需要同时开启TensorRT预测和int8预测才会有加速效果*
-*2. 使用TensorRT需要使用支持TRT功能的Paddle库，请参考[附录](https://www.paddlepaddle.org.cn/documentation/docs/zh/install/Tables.html#whl-release)下载对应的PaddlePaddle安装包，或者参考[源码编译](https://www.paddlepaddle.org.cn/documentation/docs/zh/install/compile/fromsource.html)自行编译*
+*Note:*
+*1. When using a quantitative model to predict, you need to turn on TensorRT prediction and int8 prediction at the same time to have an acceleration effect*
+*2. To use TensorRT, you need to use the Paddle library that supports the TRT function, please refer to [Appendix](https://www.paddlepaddle.org.cn/documentation/docs/zh/install/Tables.html#whl-release) to download the corresponding PaddlePaddle installation Package, or refer to [source code compilation](https://www.paddlepaddle.org.cn/documentation/docs/zh/install/compile/fromsource.html) to compile by yourself*
+
+## 4. Calculate inference speed
+After deploying the exported model, you may be very concerned about the inference speed of the deployed model. PaddleSeg provides a method to test the inference speed of the model. The following will introduce how to test the inference speed on your machine.
+* First, prepare the test data set (it is recommended to use more than 100 original images, do not use annotated images)
+* Execute the following commands in the terminal：
+```shell
+python deploy/python/infer_timer.py \
+--config output/BisenetV2/deploy.yaml \
+--image_path /path/to/data_dir \
+```
+> Among them, `/path/to/data_dir` refers to the path where the image is stored, please modify it according to the actual situation.
+> `data_dir` could be a single image or a directory.
+> When you do this, we recommend you using a directory containing multiple images as `data_dir` to get a more reliable average value of the inference speed.
+
+### Note
+* 1、If the `image_num` which you specify is greater than the total number of images stored in `image_path`, we will use the actual number of images.
+* 2、This method only calculates the inference speed and does not involve obtaining segmentation results. If you want to obtain the segmentation results obtained by inference, please run as indicated in `3`.
+* 3、This method only calculates the inferencing time, not include pre-processing time and post-processing time.
+* 4、The result is related to various factors such as `machine configuration`, `memory`, `image resolution`, etc. The results are for reference only.
+
+Parameter instruction:
+|Parameter|Effection|Is required|Default|
+|-|-|-|-|
+|config|**Configuration file generated when exporting the model**, instead of the configuration file in the configs directory|Yes|-|
+|image_path|The path or directory of the test image.|Yes|-|
+|image_num|The number of test images, used to calculate the average.|No|100|
+|use_trt|Whether to enable TensorRT to accelerate prediction.|No|No|
+|use_int8|Whether to run in int8 mode when starting TensorRT prediction.|No|No|
+|batch_size|Batch sizein single card.|No|The value specified in the configuration file.|

--- a/deploy/python/README_CN.md
+++ b/deploy/python/README_CN.md
@@ -1,0 +1,66 @@
+简体中文 | [English](README.md)
+# 本地Inference部署
+
+## 1. 说明
+
+本方案旨在提供一个PaddlePaddle跨平台图像分割模型的Python预测部署方案作为参考，用户通过一定的配置，加上少量的代码，即可把模型集成到自己的服务中，完成图像分割的任务。
+
+## 2. 前置准备
+
+请参考[文档](../../export/export/model_export.md)导出你的模型, 或点击下载我们的[样例模型](https://paddleseg.bj.bcebos.com/dygraph/demo/bisenet_demo_model.tar.gz)用于测试。
+
+接着准备一张测试图片用于试验效果，我们提供了cityscapes验证集中的一张[图片](https://paddleseg.bj.bcebos.com/dygraph/demo/cityscapes_demo.png)用于演示效果，如果您的模型是使用其他数据集训练的，请自行准备测试图片。
+
+## 3. 预测
+
+在终端输入以下命令进行预测:
+```shell
+python deploy/python/infer.py --config /path/to/deploy.yaml --image_path
+```
+
+参数说明如下:
+|参数名|用途|是否必选项|默认值|
+|-|-|-|-|
+|config|**导出模型时生成的配置文件**, 而非configs目录下的配置文件|是|-|
+|image_path|预测图片的路径或者目录|是|-|
+|use_trt|是否开启TensorRT来加速预测|否|否|
+|use_int8|启动TensorRT预测时，是否以int8模式运行|否|否|
+|batch_size|单卡batch size|否|配置文件中指定值|
+|save_dir|保存预测结果的目录|否|output|
+|with_argmax|对预测结果进行argmax操作|否|否|
+
+*测试样例和预测结果如下*
+![cityscape_predict_demo.png](../../../docs/images/cityscapes_predict_demo.png)
+
+*注意：*
+*1. 当使用量化模型预测时，需要同时开启TensorRT预测和int8预测才会有加速效果*
+*2. 使用TensorRT需要使用支持TRT功能的Paddle库，请参考[附录](https://www.paddlepaddle.org.cn/documentation/docs/zh/install/Tables.html#whl-release)下载对应的PaddlePaddle安装包，或者参考[源码编译](https://www.paddlepaddle.org.cn/documentation/docs/zh/install/compile/fromsource.html)自行编译*
+
+## 4. 计算推理速度
+将导出后的模型进行部署后，你可能很关心部署后模型的推理速度。PaddleSeg提供了测试模型推理速度的方法。以下将介绍如何在你的机器上进行推理速度测试。
+* 首先，准备测试数据集（建议使用 100 张以上的原始图像，不要使用标注图像）
+* 在终端执行以下命令：
+```shell
+python deploy/python/infer_timer.py \
+--config output/BisenetV2/deploy.yaml \
+--image_path /path/to/data_dir \
+```
+> 其中 /path/to/data_dir 指存放图像的路径，请根据实际情况自行修改。
+> data_dir 支持单张图像，也支持图像文件目录。
+> 进行测速时，我们建议你使用包含多张图像的文件目录以得到更加可靠的推理速度平均值。
+
+### 注意
+* 1、如果你所指定的 `image_num` 大于 `image_path` 中所存放的图像总数，将以实际图像数目进行测试。
+* 2、本方法仅计算推理速度，不涉及获取分割结果。如果想获取推理得到的分割结果，请按 `3` 中所指示的方法运行。
+* 3、本方法仅计算推理耗时，不包括预处理与后处理耗时。
+* 4、测试结果与`机器配置`、`显存占用情况`、`图像分辨率`等多种因素相关，结果仅供参考。
+
+参数说明如下:
+|参数名|用途|是否必选项|默认值|
+|-|-|-|-|
+|config|**导出模型时生成的配置文件**, 而非configs目录下的配置文件|是|-|
+|image_path|预测图片的路径或者目录|是|-|
+|image_num|预测图片的数目，用以计算平均值|否|100|
+|use_trt|是否开启TensorRT来加速预测|否|否|
+|use_int8|启动TensorRT预测时，是否以int8模式运行|否|否|
+|batch_size|单卡batch size|否|配置文件中指定值|

--- a/deploy/python/infer_timer.py
+++ b/deploy/python/infer_timer.py
@@ -1,0 +1,230 @@
+# Copyright (c) 2021 PaddlePaddle Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import codecs
+import os
+
+import yaml
+import numpy as np
+import paddleseg.transforms as T
+from paddle.inference import create_predictor, PrecisionType
+from paddle.inference import Config as PredictConfig
+from paddleseg.cvlibs import manager
+from paddleseg.utils import get_sys_env, logger, config_check
+from paddleseg.utils.visualize import get_pseudo_color_map
+
+
+import time
+from paddleseg.utils import TimeAverager
+
+class DeployConfig:
+    def __init__(self, path):
+        with codecs.open(path, 'r', 'utf-8') as file:
+            self.dic = yaml.load(file, Loader=yaml.FullLoader)
+
+        self._transforms = self._load_transforms(
+            self.dic['Deploy']['transforms'])
+        self._dir = os.path.dirname(path)
+
+    @property
+    def transforms(self):
+        return self._transforms
+
+    @property
+    def model(self):
+        return os.path.join(self._dir, self.dic['Deploy']['model'])
+
+    @property
+    def params(self):
+        return os.path.join(self._dir, self.dic['Deploy']['params'])
+
+    def _load_transforms(self, t_list):
+        com = manager.TRANSFORMS
+        transforms = []
+        for t in t_list:
+            ctype = t.pop('type')
+            transforms.append(com[ctype](**t))
+
+        return T.Compose(transforms)
+
+
+class Predictor:
+    def __init__(self, args):
+        self.cfg = DeployConfig(args.cfg)
+        self.args = args
+
+        pred_cfg = PredictConfig(self.cfg.model, self.cfg.params)
+        pred_cfg.disable_glog_info()
+        if self.args.use_gpu:
+            pred_cfg.enable_use_gpu(100, 0)
+
+            if self.args.use_trt:
+                ptype = PrecisionType.Int8 if args.use_int8 else PrecisionType.Float32
+                pred_cfg.enable_tensorrt_engine(
+                    workspace_size=1 << 30,
+                    max_batch_size=1,
+                    min_subgraph_size=3,
+                    precision_mode=ptype,
+                    use_static=False,
+                    use_calib_mode=False)
+
+        self.predictor = create_predictor(pred_cfg)
+
+        # 1.Init a timer
+        self.cost_averager = TimeAverager()
+
+
+    def preprocess(self, img):
+        return self.cfg.transforms(img)[0]
+
+    def run(self, imgs):
+        if not isinstance(imgs, (list, tuple)):
+            imgs = [imgs]
+
+        num = len(imgs)
+        input_names = self.predictor.get_input_names()
+        input_handle = self.predictor.get_input_handle(input_names[0])
+        results = []
+
+        logger.info('Got {} images, ready for inferencing'.format(num))
+        logger.info('...')
+        logger.info('..')
+        logger.info('.')
+
+        for i in range(0, num, self.args.batch_size):
+
+            data = np.array([
+                self.preprocess(img) for img in imgs[i:i + self.args.batch_size]
+            ])
+            input_handle.reshape(data.shape)
+            input_handle.copy_from_cpu(data)
+
+            # 2.Start
+            start = time.time() 
+
+            self.predictor.run()
+
+            # 3.End
+            self.cost_averager.record(time.time() - start)
+
+            logger.info('The end of this inferencing. Time cost is : {} (s)'.format(time.time() - start))
+            #print('The end of this inferencing. Time cost is : {} (s)'.format(time.time() - start))
+
+
+            output_names = self.predictor.get_output_names()
+            output_handle = self.predictor.get_output_handle(output_names[0])
+            results.append(output_handle.copy_to_cpu())
+
+        # 4.Return average time
+        time_result = self.cost_averager.get_average()
+        return time_result
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='Model training')
+
+    # params of training
+    parser.add_argument(
+        "--config",
+        dest="cfg",
+        help="The config file.",
+        default=None,
+        type=str,
+        required=True)
+    
+    parser.add_argument(
+        '--image_path',
+        dest='image_path',
+        help='The directory or path of the image to be predicted.',
+        type=str,
+        default=None,
+        required=True)
+    
+    parser.add_argument(
+        '--batch_size',
+        dest='batch_size',
+        help='Mini batch size of one gpu or cpu.',
+        type=int,
+        default=1)
+
+    parser.add_argument(
+        '--use_trt',
+        dest='use_trt',
+        help='Whether to use Nvidia TensorRT to accelerate prediction.',
+        action='store_true')
+
+    parser.add_argument(
+        '--use_int8',
+        dest='use_int8',
+        help='Whether to use Int8 prediction when using TensorRT prediction.',
+        action='store_true')
+
+    parser.add_argument(
+        '--image_num',
+        dest='image_num',
+        help='The number of images which used to caculate inference time.',
+        default=100)
+
+    return parser.parse_args()
+
+
+def get_images(image_num,image_path, support_ext=".jpg|.jpeg|.png"):
+    if not os.path.exists(image_path):
+        raise Exception(f"Image path {image_path} invalid")
+
+    # If given a file path.
+    if os.path.isfile(image_path): 
+        return [image_path]
+
+    # If given a directory which contains images.
+    imgs = []
+    image_num = int(image_num)
+
+    cnt = 0 # Record the readed image number.
+    for item in os.listdir(image_path):
+        if cnt < image_num: 
+            cnt = cnt + 1
+            ext = os.path.splitext(item)[1][1:].strip().lower()
+            if (len(ext) > 0 and ext in support_ext):
+                    item_path = os.path.join(image_path, item)
+                    imgs.append(item_path)
+        else:
+            break # The rest part is no need to read.
+
+    return imgs
+
+
+def main(args):
+    # Show the configs
+    env_info = get_sys_env()
+    info = ['{}: {}'.format(k, v) for k, v in env_info.items()]
+    info = '\n'.join(['', format('Environment Information', '-^48s')] + info +
+                     ['-' * 48])
+    logger.info(info)
+
+    # Create predictor for exported model
+    args.use_gpu = True if env_info['Paddle compiled with cuda'] and env_info[
+        'GPUs used'] else False
+    predictor = Predictor(args)
+
+    # Do inference 
+    time_result = predictor.run(get_images(args.image_num,args.image_path))
+    FPS = 1 / time_result
+    
+    logger.info('Perform a total of {} inferences，the average inference time is : {} (s), FPS is : {}'.format(args.image_num,time_result,FPS))
+
+
+if __name__ == '__main__':
+    args = parse_args()
+    main(args)

--- a/docs/deployment/inference/inference.md
+++ b/docs/deployment/inference/inference.md
@@ -1,36 +1,68 @@
-# 本地Inference部署
+English | [简体中文](inference_cn.md)
+# Local inference deployment
 
-## 1. 说明
+## 1. Instruction
 
-本方案旨在提供一个PaddlePaddle跨平台图像分割模型的Python预测部署方案作为参考，用户通过一定的配置，加上少量的代码，即可把模型集成到自己的服务中，完成图像分割的任务。
+This solution aims to provide a Python prediction deployment solution for the PaddlePaddle cross-platform image segmentation model as a reference. Users can integrate the model into their own services through a certain configuration and add a small amount of code to complete the task of image segmentation.
 
-## 2. 前置准备
 
-请使用**模型导出**您的模型, 或点击下载我们的[样例模型](https://paddleseg.bj.bcebos.com/dygraph/demo/bisenet_demo_model.tar.gz)用于测试。
+## 2. Pre-preparation
 
-接着准备一张测试图片用于试验效果，我们提供了cityscapes验证集中的一张[图片](https://paddleseg.bj.bcebos.com/dygraph/demo/cityscapes_demo.png)用于演示效果，如果您的模型是使用其他数据集训练的，请自行准备测试图片。
+Please refer to [document](../../export/export/model_export.md) to export your model, or click to download our [sample model](https://paddleseg.bj.bcebos.com/dygraph/demo/bisenet_demo_model.tar.gz) is used for testing.
 
-## 3. 预测
+Then prepare a picture for the test effect, we provide a [picture] (https://paddleseg.bj.bcebos.com/dygraph/demo/cityscapes_demo.png) in the cityscapes verification set to see the effect, if your model is trained by other data sets, please prepare test images by yourself.
 
-在终端输入以下命令进行预测:
+
+## 3. Prediction
+
+Enter the following command in the terminal to make predictions:
 ```shell
 python deploy/python/infer.py --config /path/to/deploy.yaml --image_path
 ```
 
-参数说明如下:
-|参数名|用途|是否必选项|默认值|
+Parameters:
+|Parameter|Effection|Is required|Default|
 |-|-|-|-|
-|config|**导出模型时生成的配置文件**, 而非configs目录下的配置文件|是|-|
-|image_path|预测图片的路径或者目录|是|-|
-|use_trt|是否开启TensorRT来加速预测|否|否|
-|use_int8|启动TensorRT预测时，是否以int8模式运行|否|否|
-|batch_size|单卡batch size|否|配置文件中指定值|
-|save_dir|保存预测结果的目录|否|output|
-|with_argmax|对预测结果进行argmax操作|否|否|
+|config|**Configuration file generated when exporting the model**, instead of the configuration file in the configs directory|Yes|-|
+|image_path|The path or directory of the test image.|Yes|-|
+|use_trt|Whether to enable TensorRT to accelerate prediction.|No|No|
+|use_int8|Whether to run in int8 mode when starting TensorRT prediction.|No|No|
+|batch_size|Batch sizein single card.|No|The value specified in the configuration file.|
+|save_dir|The directory of prediction results.|No|output|
+|with_argmax|Perform argmax operation on the prediction results.|No|No|
 
-*测试样例和预测结果如下*
+*The test sample and prediction result*
 ![cityscape_predict_demo.png](../../../docs/images/cityscapes_predict_demo.png)
 
-*注意：*
-*1. 当使用量化模型预测时，需要同时开启TensorRT预测和int8预测才会有加速效果*
-*2. 使用TensorRT需要使用支持TRT功能的Paddle库，请参考[附录](https://www.paddlepaddle.org.cn/documentation/docs/zh/install/Tables.html#whl-release)下载对应的PaddlePaddle安装包，或者参考[源码编译](https://www.paddlepaddle.org.cn/documentation/docs/zh/install/compile/fromsource.html)自行编译*
+*Note:*
+*1. When using a quantitative model to predict, you need to turn on TensorRT prediction and int8 prediction at the same time to have an acceleration effect*
+*2. To use TensorRT, you need to use the Paddle library that supports the TRT function, please refer to [Appendix](https://www.paddlepaddle.org.cn/documentation/docs/zh/install/Tables.html#whl-release) to download the corresponding PaddlePaddle installation Package, or refer to [source code compilation](https://www.paddlepaddle.org.cn/documentation/docs/zh/install/compile/fromsource.html) to compile by yourself*
+
+## 4. Calculate inference speed
+After deploying the exported model, you may be very concerned about the inference speed of the deployed model. PaddleSeg provides a method to test the inference speed of the model. The following will introduce how to test the inference speed on your machine.
+* First, prepare the test data set (it is recommended to use more than 100 original images, do not use annotated images)
+* Execute the following commands in the terminal：
+```shell
+python deploy/python/infer_timer.py \
+--config output/BisenetV2/deploy.yaml \
+--image_path /path/to/data_dir \
+```
+> Among them, `/path/to/data_dir` refers to the path where the image is stored, please modify it according to the actual situation.
+> `data_dir` could be a single image or a directory.
+> When you do this, we recommend you using a directory containing multiple images as `data_dir` to get a more reliable average value of the inference speed.
+
+### Note
+* 1、If the `image_num` which you specify is greater than the total number of images stored in `image_path`, we will use the actual number of images.
+* 2、This method only calculates the inference speed and does not involve obtaining segmentation results. If you want to obtain the segmentation results obtained by inference, please run as indicated in `3`.
+* 3、This method only calculates the inferencing time, not include pre-processing time and post-processing time.
+* 4、The result is related to various factors such as `machine configuration`, `memory`, `image resolution`, etc. The results are for reference only.
+
+Parameter instruction:
+|Parameter|Effection|Is required|Default|
+|-|-|-|-|
+|config|**Configuration file generated when exporting the model**, instead of the configuration file in the configs directory|Yes|-|
+|image_path|The path or directory of the test image.|Yes|-|
+|image_num|The number of test images, used to calculate the average.|No|100|
+|use_trt|Whether to enable TensorRT to accelerate prediction.|No|No|
+|use_int8|Whether to run in int8 mode when starting TensorRT prediction.|No|No|
+|batch_size|Batch sizein single card.|No|The value specified in the configuration file.|

--- a/docs/deployment/inference/inference_cn.md
+++ b/docs/deployment/inference/inference_cn.md
@@ -1,0 +1,66 @@
+简体中文 | [English](inference.md)
+# 本地Inference部署
+
+## 1. 说明
+
+本方案旨在提供一个PaddlePaddle跨平台图像分割模型的Python预测部署方案作为参考，用户通过一定的配置，加上少量的代码，即可把模型集成到自己的服务中，完成图像分割的任务。
+
+## 2. 前置准备
+
+请参考[文档](../../export/export/model_export.md)导出你的模型, 或点击下载我们的[样例模型](https://paddleseg.bj.bcebos.com/dygraph/demo/bisenet_demo_model.tar.gz)用于测试。
+
+接着准备一张测试图片用于试验效果，我们提供了cityscapes验证集中的一张[图片](https://paddleseg.bj.bcebos.com/dygraph/demo/cityscapes_demo.png)用于演示效果，如果您的模型是使用其他数据集训练的，请自行准备测试图片。
+
+## 3. 预测
+
+在终端输入以下命令进行预测:
+```shell
+python deploy/python/infer.py --config /path/to/deploy.yaml --image_path
+```
+
+参数说明如下:
+|参数名|用途|是否必选项|默认值|
+|-|-|-|-|
+|config|**导出模型时生成的配置文件**, 而非configs目录下的配置文件|是|-|
+|image_path|预测图片的路径或者目录|是|-|
+|use_trt|是否开启TensorRT来加速预测|否|否|
+|use_int8|启动TensorRT预测时，是否以int8模式运行|否|否|
+|batch_size|单卡batch size|否|配置文件中指定值|
+|save_dir|保存预测结果的目录|否|output|
+|with_argmax|对预测结果进行argmax操作|否|否|
+
+*测试样例和预测结果如下*
+![cityscape_predict_demo.png](../../../docs/images/cityscapes_predict_demo.png)
+
+*注意：*
+*1. 当使用量化模型预测时，需要同时开启TensorRT预测和int8预测才会有加速效果*
+*2. 使用TensorRT需要使用支持TRT功能的Paddle库，请参考[附录](https://www.paddlepaddle.org.cn/documentation/docs/zh/install/Tables.html#whl-release)下载对应的PaddlePaddle安装包，或者参考[源码编译](https://www.paddlepaddle.org.cn/documentation/docs/zh/install/compile/fromsource.html)自行编译*
+
+## 4. 计算推理速度
+将导出后的模型进行部署后，你可能很关心部署后模型的推理速度。PaddleSeg提供了测试模型推理速度的方法。以下将介绍如何在你的机器上进行推理速度测试。
+* 首先，准备测试数据集（建议使用 100 张以上的原始图像，不要使用标注图像）
+* 在终端执行以下命令：
+```shell
+python deploy/python/infer_timer.py \
+--config output/BisenetV2/deploy.yaml \
+--image_path /path/to/data_dir \
+```
+> 其中 /path/to/data_dir 指存放图像的路径，请根据实际情况自行修改。
+> data_dir 支持单张图像，也支持图像文件目录。
+> 进行测速时，我们建议你使用包含多张图像的文件目录以得到更加可靠的推理速度平均值。
+
+### 注意
+* 1、如果你所指定的 `image_num` 大于 `image_path` 中所存放的图像总数，将以实际图像数目进行测试。
+* 2、本方法仅计算推理速度，不涉及获取分割结果。如果想获取推理得到的分割结果，请按 `3` 中所指示的方法运行。
+* 3、本方法仅计算推理耗时，不包括预处理与后处理耗时。
+* 4、测试结果与`机器配置`、`显存占用情况`、`图像分辨率`等多种因素相关，结果仅供参考。
+
+参数说明如下:
+|参数名|用途|是否必选项|默认值|
+|-|-|-|-|
+|config|**导出模型时生成的配置文件**, 而非configs目录下的配置文件|是|-|
+|image_path|预测图片的路径或者目录|是|-|
+|image_num|预测图片的数目，用以计算平均值|否|100|
+|use_trt|是否开启TensorRT来加速预测|否|否|
+|use_int8|启动TensorRT预测时，是否以int8模式运行|否|否|
+|batch_size|单卡batch size|否|配置文件中指定值|


### PR DESCRIPTION
1、Add 'infer_timer.py', an inference timing module, with command line optional parameter image_num (default: 100). The module will calculate the average inference time of the derived model based on this parameter.
2、Add module instruction.