### PR TITLE
fix weighted cross entropy bug

### DIFF
--- a/paddleseg/models/losses/cross_entropy_loss.py
+++ b/paddleseg/models/losses/cross_entropy_loss.py
@@ -41,13 +41,17 @@ class CrossEntropyLoss(nn.Layer):
                  top_k_percent_pixels=1.0,
                  data_format='NCHW'):
         super(CrossEntropyLoss, self).__init__()
-        if weight is not None:
-            weight = paddle.to_tensor(weight, dtype='float32')
-        self.weight = weight
         self.ignore_index = ignore_index
         self.top_k_percent_pixels = top_k_percent_pixels
         self.EPS = 1e-8
         self.data_format = data_format
+        if weight is not None:
+            self.weight = paddle.to_tensor(weight, dtype='float32')
+            long_weight = weight + [0] * (256 - len(weight))
+            self.long_weight = paddle.to_tensor(long_weight, dtype='float32')
+        else:
+            self.weight = None
+            self.long_weight = None
 
     def forward(self, logit, label, semantic_weights=None):
         """
@@ -75,7 +79,7 @@ class CrossEntropyLoss(nn.Layer):
             label,
             ignore_index=self.ignore_index,
             reduction='none',
-            weight=self.weight)
+            weight=self.long_weight)
 
         mask = label != self.ignore_index
         mask = paddle.cast(mask, 'float32')


### PR DESCRIPTION
修复weighted cross entropy的bug.
该问题也涉及paddle cross entropy op的问题，需要同步进行修复，修复代码参考最下方

报错日志：
![image](https://user-images.githubusercontent.com/30695251/128689916-15a163f4-4e11-4b31-9f9e-0ff5da4ddf36.png)

Bug复现代码：
```
import paddle
from paddleseg.models.losses import CrossEntropyLoss

input_data = paddle.rand(shape=[4, 7, 125, 125])
label_data = paddle.randint(0, 7, shape=[4, 125, 125], dtype="int64")
label_data[0, 0, 0] = 255
print(paddle.unique(label_data))
weight = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7]

loss = CrossEntropyLoss(weight=weight)
out = loss(input_data, label_data)
print(out)
```

按下面的代码修改你的paddle cross entropy op源码（后续我们也会将该修复提交至paddle）：
![image](https://user-images.githubusercontent.com/30695251/128690683-27230ca4-0967-4ea5-8cee-e47a49563ddb.png)

按上述方法修复后，Bug复现代码不再报错。

### 如何寻找paddle源码？
1 寻找python所在位置
2 进入安装的paddle代码所在位置
示例：
![image](https://user-images.githubusercontent.com/30695251/128984140-507b1525-6f6b-4700-83fc-f57108ed33d7.png)

