### PR TITLE
Fix the api error for mobilenetv3

### DIFF
--- a/paddleseg/models/backbones/mobilenetv3.py
+++ b/paddleseg/models/backbones/mobilenetv3.py
@@ -308,8 +308,8 @@ class SEModule(nn.Layer):
         outputs = self.conv1(outputs)
         outputs = F.relu(outputs)
         outputs = self.conv2(outputs)
-        outputs = F.hard_sigmoid(outputs)
-        return paddle.multiply(x=inputs, y=outputs, axis=0)
+        outputs = F.hardsigmoid(outputs)
+        return paddle.multiply(x=inputs, y=outputs)
 
 
 def MobileNetV3_small_x0_35(**kwargs):


### PR DESCRIPTION
Refer to the api and [paddleclas](https://github.com/PaddlePaddle/PaddleClas/blob/release/2.2/ppcls/arch/backbone/legendary_models/mobilenet_v3.py#L343)




