### PR TITLE
[CityscapeSOTA] Fix an evaluation bug

### DIFF
--- a/contrib/CityscapesSOTA/scripts/train.py
+++ b/contrib/CityscapesSOTA/scripts/train.py
@@ -207,7 +207,7 @@ def train(model,
             if (iter % save_interval == 0
                     or iter == iters) and (val_dataset is not None):
                 num_workers = 1 if num_workers > 0 else 0
-                mean_iou, acc, class_iou, class_acc, kappa = evaluate(
+                metircs = evaluate(
                     model,
                     val_dataset,
                     aug_eval=aug_eval,
@@ -218,6 +218,7 @@ def train(model,
                     stride=None,
                     crop_size=None,
                     num_workers=num_workers)
+                mean_iou, acc = metircs[0], metrics[1]
                 model.train()
 
             if (iter % save_interval == 0 or iter == iters) and local_rank == 0:

--- a/contrib/CityscapesSOTA/scripts/train.py
+++ b/contrib/CityscapesSOTA/scripts/train.py
@@ -207,7 +207,7 @@ def train(model,
             if (iter % save_interval == 0
                     or iter == iters) and (val_dataset is not None):
                 num_workers = 1 if num_workers > 0 else 0
-                mean_iou, acc = evaluate(
+                mean_iou, acc, class_iou, class_acc, kappa = evaluate(
                     model,
                     val_dataset,
                     aug_eval=aug_eval,


### PR DESCRIPTION
Function evaluate() in PaddleSeg will return 5 parameters, but in CityscapesSOTA it receives only 2 which caused error like 'ValueError:too many values to unpack(expected 2)'