### PR TITLE
[Fix] Fix GINet export bugs

### DIFF
--- a/paddleseg/models/layers/layer_libs.py
+++ b/paddleseg/models/layers/layer_libs.py
@@ -254,7 +254,7 @@ class JPU(nn.Layer):
             self.conv4(inputs[-2]),
             self.conv3(inputs[-3])
         ]
-        size = feats[-1].shape[2:]
+        size = paddle.shape(feats[-1])[2:]
         feats[-2] = F.interpolate(
             feats[-2], size, mode='bilinear', align_corners=True)
         feats[-3] = F.interpolate(


### PR DESCRIPTION
解决动转静过程各个语法不兼容导致的报错问题。 issue [#1498](https://github.com/PaddlePaddle/PaddleSeg/issues/1498#issue-1044835403)
修改的代码可以成功导出，并通过 infer 部署测试，能得到正确的预测图片。

注意！：修改后需要在最新的 paddle develop 和 paddleseg=2.3.0 下运行，不然依旧可能会形状推断不正确报错。

![image](https://user-images.githubusercontent.com/34859558/140857587-cba44eb7-e0d2-4ed4-8266-42dbff6dd500.png)
