### PR TITLE
[Benchmark] Change some settings for seg train performance

### DIFF
--- a/benchmark/configs/segformer_b0.yml
+++ b/benchmark/configs/segformer_b0.yml
@@ -3,6 +3,9 @@ _base_: './cityscapes_30imgs.yml'
 batch_size: 2
 iters: 500
 
+# Conv config
+export FLAGS_cudnn_exhaustive_search=True
+
 model:
   type: SegFormer_B0
   num_classes: 19

--- a/benchmark/run_all.sh
+++ b/benchmark/run_all.sh
@@ -24,7 +24,7 @@ model_name_list=(fastscnn segformer_b0 ocrnet_hrnetw48)
 fp_item_list=(fp32)     # set fp32 or fp16, segformer_b0 doesn't support fp16 with Paddle2.1.2
 bs_list=(2)
 max_iters=500           # control the test time
-num_workers=5           # num_workers for dataloader
+num_workers=5           # num_workers for dataloader, as for fastscnn and ocrnet_hrnetw48, it is better to set 8
 
 for model_name in ${model_name_list[@]}; do
       for fp_item in ${fp_item_list[@]}; do


### PR DESCRIPTION
- As we found from model benchmark, once adjust the num_workers from 5 to 8 in fastscnn or ocrnet models, the trainning performance will acclerate, and segformer model would benefit from openning the option of cudnn exhaustitve search.