### PR TITLE
[Benchmark] Revert useless setting changes

### DIFF
--- a/benchmark/configs/segformer_b0.yml
+++ b/benchmark/configs/segformer_b0.yml
@@ -3,9 +3,6 @@ _base_: './cityscapes_30imgs.yml'
 batch_size: 2
 iters: 500
 
-# Conv config
-export FLAGS_cudnn_exhaustive_search=True
-
 model:
   type: SegFormer_B0
   num_classes: 19


### PR DESCRIPTION
- I am so sorry for [PR1683](https://github.com/PaddlePaddle/PaddleSeg/pull/1683), the `export FLAGS_cudnn_exhaustive_search=True` shall not be added into `.yaml`.  So I revet the useless changes.