### PR TITLE
[Fix] Update visualize.py

### DIFF
--- a/paddleseg/utils/visualize.py
+++ b/paddleseg/utils/visualize.py
@@ -40,7 +40,7 @@ def visualize(image, result, color_map, save_dir=None, weight=0.6):
     c1 = cv2.LUT(result, color_map[:, 0])
     c2 = cv2.LUT(result, color_map[:, 1])
     c3 = cv2.LUT(result, color_map[:, 2])
-    pseudo_img = np.dstack((c1, c2, c3))
+    pseudo_img = np.dstack((c3, c2, c1))
 
     im = cv2.imread(image)
     vis_result = cv2.addWeighted(im, weight, pseudo_img, 1 - weight, 0)


### PR DESCRIPTION
（1）改正说明：
color_map 应该是RGB的数组
- 在 def visualize(image, result, color_map, save_dir=None, weight=0.6)中，是opencv读取，读取的顺序是BGR，既 c1->R, c2->G ,c3->B.  所以如果使用opencv进行颜色叠加的话，应该改正  pseudo_img = np.dstack((c1, c2, c3))  ---> pseudo_img = np.dstack((c3, c2, c1)), 这样生成的伪彩图才是BGR形式，可以使用cv2.addWeight和原图进行叠加, 并且正确保存；

- 在 def get_pseudo_color_map(pred, color_map=None) 生成伪彩图的过程，PIL 读取图片的数据就是RGB， 所以此时将RGB格式的color_map输入的话，得到就是正确的图像格式。

（2）验证：
使用predict.py 对于图像进行预测的时候，将mask weight=0生成预测伪彩图，看生成的add_prediction, psedu_color_prediction同样类别的颜色完全不同。改正后，完全一样。
参见predict,py line 133