### PR TITLE
[TIPC] Merge benchmark to TIPC. Add 5 models.

### DIFF
--- a/benchmark/run_benchmark.sh
+++ b/benchmark/run_benchmark.sh
@@ -34,7 +34,7 @@ function _train(){
     echo "current CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES, gpus=$num_gpu_devices, batch_size=$batch_size"
 
     if [ $fp_item = "fp16" ]; then
-        use_fp16_cmd="--fp16"
+        use_fp16_cmd="--precision fp16"
     fi
     train_cmd="--config=benchmark/configs/${model_item}.yml \
                --batch_size=${batch_size} \
@@ -69,4 +69,3 @@ source ${BENCHMARK_ROOT}/scripts/run_model.sh   # 在该脚本中会对符合ben
 _set_params $@
 # _train       # 如果只想产出训练log,不解析,可取消注释
 _run     # 该函数在run_model.sh中,执行时会调用_train; 如果不联调只想要产出训练log可以注掉本行,提交时需打开
-

--- a/benchmark/run_fp16.sh
+++ b/benchmark/run_fp16.sh
@@ -9,4 +9,4 @@ python train.py --config benchmark/deeplabv3p.yml \
   --num_workers 8 \
   --log_iters 20 \
   --data_format NHWC \
-  --fp16
+  --precision fp16

--- a/paddleseg/core/train.py
+++ b/paddleseg/core/train.py
@@ -73,7 +73,7 @@ def train(model,
           losses=None,
           keep_checkpoint_max=5,
           test_config=None,
-          fp16=False,
+          precision='fp32',
           profiler_options=None,
           to_static_training=False):
     """
@@ -96,7 +96,7 @@ def train(model,
             The 'types' item is a list of object of paddleseg.models.losses while the 'coef' item is a list of the relevant coefficient.
         keep_checkpoint_max (int, optional): Maximum number of checkpoints to save. Default: 5.
         test_config(dict, optional): Evaluation config.
-        fp16 (bool, optional): Whether to use amp.
+        precision (str, optional): Use AMP if precision='fp16'. If precision='fp32', the training is normal.
         profiler_options (str, optional): The option of train profiler.
         to_static_training (bool, optional): Whether to use @to_static for training.
     """
@@ -131,7 +131,7 @@ def train(model,
     )
 
     # use amp
-    if fp16:
+    if precision:
         logger.info('use amp to train')
         scaler = paddle.amp.GradScaler(init_loss_scaling=1024)
 
@@ -172,7 +172,7 @@ def train(model,
             if hasattr(model, 'data_format') and model.data_format == 'NHWC':
                 images = images.transpose((0, 2, 3, 1))
 
-            if fp16:
+            if precision == 'fp16':
                 with paddle.amp.auto_cast(
                         enable=True,
                         custom_white_list={

--- a/paddleseg/core/train.py
+++ b/paddleseg/core/train.py
@@ -131,7 +131,7 @@ def train(model,
     )
 
     # use amp
-    if precision:
+    if precision == 'fp16':
         logger.info('use amp to train')
         scaler = paddle.amp.GradScaler(init_loss_scaling=1024)
 

--- a/paddleseg/core/val.py
+++ b/paddleseg/core/val.py
@@ -78,9 +78,9 @@ def evaluate(model,
     )
 
     total_iters = len(loader)
-    intersect_area_all = 0
-    pred_area_all = 0
-    label_area_all = 0
+    intersect_area_all = paddle.zeros([1], dtype='int64')
+    pred_area_all = paddle.zeros([1], dtype='int64')
+    label_area_all = paddle.zeros([1], dtype='int64')
     logits_all = None
     label_all = None
 

--- a/test_tipc/benchmark_train.sh
+++ b/test_tipc/benchmark_train.sh
@@ -3,8 +3,6 @@ source test_tipc/common_func.sh
 
 # set env
 python=python
-export model_branch=`git symbolic-ref HEAD 2>/dev/null | cut -d"/" -f 3`
-export model_commit=$(git log|head -n1|awk '{print $2}')
 export str_tmp=$(echo `pip list|grep paddlepaddle-gpu|awk -F ' ' '{print $2}'`)
 export frame_version=${str_tmp%%.post*}
 export frame_commit=$(echo `${python} -c "import paddle;print(paddle.version.commit)"`)

--- a/test_tipc/benchmark_train.sh
+++ b/test_tipc/benchmark_train.sh
@@ -1,0 +1,258 @@
+#!/bin/bash
+source test_tipc/common_func.sh
+
+# set env
+python=python
+export model_branch=`git symbolic-ref HEAD 2>/dev/null | cut -d"/" -f 3`
+export model_commit=$(git log|head -n1|awk '{print $2}')
+export str_tmp=$(echo `pip list|grep paddlepaddle-gpu|awk -F ' ' '{print $2}'`)
+export frame_version=${str_tmp%%.post*}
+export frame_commit=$(echo `${python} -c "import paddle;print(paddle.version.commit)"`)
+
+# run benchmark sh
+# Usage:
+# bash run_benchmark_train.sh config.txt params
+# or
+# bash run_benchmark_train.sh config.txt
+
+function func_parser_params(){
+    strs=$1
+    IFS="="
+    array=(${strs})
+    tmp=${array[1]}
+    echo ${tmp}
+}
+
+function func_sed_params(){
+    filename=$1
+    line=$2
+    param_value=$3
+    params=`sed -n "${line}p" $filename`
+    IFS=":"
+    array=(${params})
+    key=${array[0]}
+    value=${array[1]}
+    if [[ $value =~ 'benchmark_train' ]];then
+        IFS='='
+        _val=(${value})
+        param_value="${_val[0]}=${param_value}"
+    fi
+    new_params="${key}:${param_value}"
+    IFS=";"
+    cmd="sed -i '${line}s/.*/${new_params}/' '${filename}'"
+    eval $cmd
+}
+
+function set_gpu_id(){
+    string=$1
+    _str=${string:1:6}
+    IFS="C"
+    arr=(${_str})
+    M=${arr[0]}
+    P=${arr[1]}
+    gn=`expr $P - 1`
+    gpu_num=`expr $gn / $M`
+    seq=`seq -s "," 0 $gpu_num`
+    echo $seq
+}
+
+function get_repo_name(){
+    IFS=";"
+    cur_dir=$(pwd)
+    IFS="/"
+    arr=(${cur_dir})
+    echo ${arr[-1]}
+}
+
+FILENAME=$1
+# copy FILENAME as new
+new_filename="./test_tipc/benchmark_train.txt"
+cmd=`yes|cp $FILENAME $new_filename`
+FILENAME=$new_filename
+# MODE must be one of ['benchmark_train']
+MODE=$2
+PARAMS=$3
+# bash test_tipc/benchmark_train.sh test_tipc/configs/det_mv3_db_v2_0/train_benchmark.txt  benchmark_train dynamic_bs8_null_DP_N1C1
+IFS=$'\n'
+# parser params from train_benchmark.txt
+dataline=`cat $FILENAME`
+# parser params
+IFS=$'\n'
+lines=(${dataline})
+model_name=$(func_parser_value "${lines[1]}")
+
+# 获取benchmark_params所在的行数
+line_num=`grep -n "train_benchmark_params" $FILENAME  | cut -d ":" -f 1`
+# for train log parser
+batch_size=$(func_parser_value "${lines[line_num]}")
+line_num=`expr $line_num + 1`
+fp_items=$(func_parser_value "${lines[line_num]}")
+line_num=`expr $line_num + 1`
+epoch=$(func_parser_value "${lines[line_num]}")
+
+line_num=`expr $line_num + 1`
+profile_option_key=$(func_parser_key "${lines[line_num]}")
+profile_option_params=$(func_parser_value "${lines[line_num]}")
+profile_option="${profile_option_key}:${profile_option_params}"
+
+line_num=`expr $line_num + 1`
+flags_value=$(func_parser_value "${lines[line_num]}")
+# set flags
+IFS=";"
+flags_list=(${flags_value})
+for _flag in ${flags_list[*]}; do
+    cmd="export ${_flag}"
+    eval $cmd
+done
+
+# set log_name
+repo_name=$(get_repo_name )
+SAVE_LOG=${BENCHMARK_LOG_DIR:-$(pwd)}   # */benchmark_log
+mkdir -p "${SAVE_LOG}/benchmark_log/"
+status_log="${SAVE_LOG}/benchmark_log/results.log"
+
+# The number of lines in which train params can be replaced.
+line_python=3
+line_gpuid=4
+line_precision=6
+line_epoch=7
+line_batchsize=9
+line_profile=13
+line_eval_py=24
+line_export_py=30
+
+func_sed_params "$FILENAME" "${line_eval_py}" "null"
+func_sed_params "$FILENAME" "${line_export_py}" "null"
+func_sed_params "$FILENAME" "${line_python}"  "$python"
+
+# if params
+if  [ ! -n "$PARAMS" ] ;then
+    # PARAMS input is not a word.
+    IFS="|"
+    batch_size_list=(${batch_size})
+    fp_items_list=(${fp_items})
+    device_num_list=(N1C4)
+    run_mode="DP"
+else
+    # parser params from input: modeltype_bs{fp_item}_{device_num}
+    IFS="_"
+    params_list=(${PARAMS})
+    model_type=${params_list[0]}
+    batch_size=${params_list[1]}
+    batch_size=`echo  ${batch_size} | tr -cd "[0-9]" `
+    precision=${params_list[2]}
+    # run_process_type=${params_list[3]}
+    run_mode=${params_list[3]}
+    device_num=${params_list[4]}
+    IFS=";"
+
+    if [ ${precision} = "null" ];then
+        precision="fp32"
+    fi
+
+    fp_items_list=($precision)
+    batch_size_list=($batch_size)
+    device_num_list=($device_num)
+fi
+
+IFS="|"
+for batch_size in ${batch_size_list[*]}; do
+    for precision in ${fp_items_list[*]}; do
+        for device_num in ${device_num_list[*]}; do
+            # sed batchsize and precision
+            func_sed_params "$FILENAME" "${line_precision}" "$precision"
+            func_sed_params "$FILENAME" "${line_batchsize}" "$MODE=$batch_size"
+            func_sed_params "$FILENAME" "${line_epoch}" "$MODE=$epoch"
+            gpu_id=$(set_gpu_id $device_num)
+
+            if [ ${#gpu_id} -le 1 ];then
+                run_process_type="SingleP"
+                log_path="$SAVE_LOG/profiling_log"
+                mkdir -p $log_path
+                log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_process_type}_${run_mode}_${device_num}_profiling"
+                func_sed_params "$FILENAME" "${line_gpuid}" "0"  # sed used gpu_id
+                # set profile_option params
+                tmp=`sed -i "${line_profile}s/.*/${profile_option}/" "${FILENAME}"`
+
+                # run test_train_inference_python.sh
+                cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} benchmark_train > ${log_path}/${log_name} 2>&1 "
+                echo $cmd
+                eval $cmd
+                eval "cat ${log_path}/${log_name}"
+
+                # without profile
+                log_path="$SAVE_LOG/train_log"
+                speed_log_path="$SAVE_LOG/index"
+                mkdir -p $log_path
+                mkdir -p $speed_log_path
+                log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_process_type}_${run_mode}_${device_num}_log"
+                speed_log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_process_type}_${run_mode}_${device_num}_speed"
+                func_sed_params "$FILENAME" "${line_profile}" "null"  # sed profile_id as null
+                cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} benchmark_train > ${log_path}/${log_name} 2>&1 "
+                echo $cmd
+                job_bt=`date '+%Y%m%d%H%M%S'`
+                eval $cmd
+                job_et=`date '+%Y%m%d%H%M%S'`
+                export model_run_time=$((${job_et}-${job_bt}))
+                eval "cat ${log_path}/${log_name}"
+
+                # parser log
+                _model_name="${model_name}_bs${batch_size}_${precision}_${run_process_type}_${run_mode}"
+                cmd="${python} ${BENCHMARK_ROOT}/scripts/analysis.py --filename ${log_path}/${log_name} \
+                        --speed_log_file '${speed_log_path}/${speed_log_name}' \
+                        --model_name ${_model_name} \
+                        --base_batch_size ${batch_size} \
+                        --run_mode ${run_mode} \
+                        --run_process_type ${run_process_type} \
+                        --fp_item ${precision} \
+                        --keyword ips: \
+                        --skip_steps 2 \
+                        --device_num ${device_num} \
+                        --speed_unit samples/s \
+                        --convergence_key loss: "
+                echo $cmd
+                eval $cmd
+                last_status=${PIPESTATUS[0]}
+                status_check $last_status "${cmd}" "${status_log}"
+            else
+                IFS=";"
+                unset_env=`unset CUDA_VISIBLE_DEVICES`
+                run_process_type="MultiP"
+                log_path="$SAVE_LOG/train_log"
+                speed_log_path="$SAVE_LOG/index"
+                mkdir -p $log_path
+                mkdir -p $speed_log_path
+                log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_process_type}_${run_mode}_${device_num}_log"
+                speed_log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_process_type}_${run_mode}_${device_num}_speed"
+                func_sed_params "$FILENAME" "${line_gpuid}" "$gpu_id"  # sed used gpu_id
+                func_sed_params "$FILENAME" "${line_profile}" "null"  # sed --profile_option as null
+                cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} benchmark_train > ${log_path}/${log_name} 2>&1 "
+                echo $cmd
+                job_bt=`date '+%Y%m%d%H%M%S'`
+                eval $cmd
+                job_et=`date '+%Y%m%d%H%M%S'`
+                export model_run_time=$((${job_et}-${job_bt}))
+                eval "cat ${log_path}/${log_name}"
+                # parser log
+                _model_name="${model_name}_bs${batch_size}_${precision}_${run_process_type}_${run_mode}"
+
+                cmd="${python} ${BENCHMARK_ROOT}/scripts/analysis.py --filename ${log_path}/${log_name} \
+                        --speed_log_file '${speed_log_path}/${speed_log_name}' \
+                        --model_name ${_model_name} \
+                        --base_batch_size ${batch_size} \
+                        --run_mode ${run_mode} \
+                        --run_process_type ${run_process_type} \
+                        --fp_item ${precision} \
+                        --keyword ips: \
+                        --skip_steps 2 \
+                        --device_num ${device_num} \
+                        --speed_unit images/s \
+                        --convergence_key loss: "
+                echo $cmd
+                eval $cmd
+                last_status=${PIPESTATUS[0]}
+                status_check $last_status "${cmd}" "${status_log}"
+            fi
+        done
+    done
+done

--- a/test_tipc/configs/bisenetv2/train_infer_python.txt
+++ b/test_tipc/configs/bisenetv2/train_infer_python.txt
@@ -3,7 +3,7 @@ model_name:bisenetv2
 python:python3.7
 gpu_list:0|0,1
 Global.use_gpu:null|null
-Global.auto_cast:null
+--precision:null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=3

--- a/test_tipc/configs/deeplabv3p_resnet50_cityscapes/deeplabv3p_resnet50_1024x512_cityscapes.yml
+++ b/test_tipc/configs/deeplabv3p_resnet50_cityscapes/deeplabv3p_resnet50_1024x512_cityscapes.yml
@@ -1,0 +1,52 @@
+batch_size: 2
+iters: 80000
+to_static_training: False
+
+train_dataset:
+  type: Cityscapes
+  dataset_root: data/cityscapes
+  transforms:
+    - type: ResizeStepScaling
+      min_scale_factor: 0.5
+      max_scale_factor: 2.0
+      scale_step_size: 0.25
+    - type: RandomPaddingCrop
+      crop_size: [1024, 512]
+    - type: RandomHorizontalFlip
+    - type: RandomDistort
+    - type: Normalize
+  mode: train
+
+val_dataset:
+  type: Cityscapes
+  dataset_root: data/cityscapes
+  transforms:
+    - type: Normalize
+  mode: val
+
+model:
+  type: DeepLabV3P
+  backbone:
+    type: ResNet50_vd
+    output_stride: 8
+    multi_grid: [1, 2, 4]
+    pretrained: https://bj.bcebos.com/paddleseg/dygraph/resnet50_vd_ssld_v2.tar.gz
+  num_classes: 19
+  backbone_indices: [0, 3]
+  aspp_ratios: [1, 12, 24, 36]
+
+optimizer:
+  type: sgd
+  weight_decay: 0.00004
+
+lr_scheduler:
+  type: PolynomialDecay
+  learning_rate: 0.01
+  end_lr: 0
+  power: 0.9
+
+loss:
+  types:
+    - type: CrossEntropyLoss
+      ignore_index: 255
+  coef: [1]

--- a/test_tipc/configs/deeplabv3p_resnet50_cityscapes/train_infer_python.txt
+++ b/test_tipc/configs/deeplabv3p_resnet50_cityscapes/train_infer_python.txt
@@ -9,11 +9,11 @@ Global.use_gpu:null|null
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=8
 Global.pretrained_model:null
 train_model_name:best_model/model.pdparams
-train_infer_img_dir:test_tipc/data/mini_supervisely/test.txt
+train_infer_img_dir:test_tipc/data/cityscapes/test.txt
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/deeplabv3p_resnet50/deeplabv3p_resnet50_humanseg_512x512_mini_supervisely.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/deeplabv3p_resnet50_cityscapes/deeplabv3p_resnet50_1024x512_cityscapes.yml --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null
@@ -27,15 +27,15 @@ null:null
 ===========================export_params===========================
 --save_dir:
 --model_path:
-norm_export:export.py --config test_tipc/configs/deeplabv3p_resnet50/deeplabv3p_resnet50_humanseg_512x512_mini_supervisely.yml
+norm_export:export.py --config test_tipc/configs/deeplabv3p_resnet50_cityscapes/deeplabv3p_resnet50_1024x512_cityscapes.yml
 quant_export:null
 fpgm_export:null
 distill_export:null
 export1:null
 export2:null
 ===========================infer_params===========================
-infer_model:./test_tipc/output/deeplabv3p_resnet50/deeplabv3p_resnet50_os8_humanseg_512x512_100k/model.pdparams
-infer_export:export.py --config test_tipc/configs/deeplabv3p_resnet50/deeplabv3p_resnet50_humanseg_512x512_mini_supervisely.yml
+infer_model:./test_tipc/output/deeplabv3p_resnet50_cityscapes/deeplabv3p_resnet50_os8_1024x512_100k/model.pdparams
+infer_export:export.py --config test_tipc/configs/deeplabv3p_resnet50_cityscapes/deeplabv3p_resnet50_1024x512_cityscapes.yml
 infer_quant:False
 inference:deploy/python/infer.py
 --device:cpu|gpu
@@ -45,8 +45,14 @@ inference:deploy/python/infer.py
 --use_trt:False|True
 --precision:fp32|int8|fp16
 --config:
---image_path:./test_tipc/data/mini_supervisely/test.txt
+--image_path:./test_tipc/data/cityscapes/test.txt
 --save_log_path:null
 --benchmark:True
 --save_dir:
 --model_name:deeplabv3p_resnet50
+===========================train_benchmark_params==========================
+batch_size:4
+fp_items:fp32|fp16
+epoch:50
+--profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
+flags:FLAGS_cudnn_exhaustive_search=1;FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.98;FLAGS_conv_workspace_size_limit=4096

--- a/test_tipc/configs/fastscnn/fastscnn_cityscapes.yml
+++ b/test_tipc/configs/fastscnn/fastscnn_cityscapes.yml
@@ -1,0 +1,37 @@
+# The fastscnn config for train benchmark
+_base_: '../_base_/cityscapes_1024x1024.yml'
+
+batch_size: 2
+iters: 500
+
+loss:
+  types:
+    - type: CrossEntropyLoss
+  coef: [1.0, 0.4]
+
+lr_scheduler:
+  type: PolynomialDecay
+  learning_rate: 0.05
+  end_lr: 1.0e-4
+  power: 0.9
+
+model:
+  type: FastSCNN
+  num_classes: 19
+  enable_auxiliary_loss: True
+  pretrained: null
+
+train_dataset:
+  transforms:
+    - type: ResizeStepScaling
+      min_scale_factor: 0.5
+      max_scale_factor: 2.0
+      scale_step_size: 0.25
+    - type: RandomPaddingCrop
+      crop_size: [1024, 1024]
+    - type: RandomHorizontalFlip
+    - type: RandomDistort
+      brightness_range: 0.4
+      contrast_range: 0.4
+      saturation_range: 0.4
+    - type: Normalize

--- a/test_tipc/configs/fastscnn/train_infer_python.txt
+++ b/test_tipc/configs/fastscnn/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/val.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/fastscnn/fastscnn_cityscapes_1024x1024_160k.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/fastscnn/fastscnn_cityscapes.yml --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null
@@ -27,7 +27,7 @@ null:null
 ===========================export_params===========================
 --save_dir:
 --model_path:
-norm_export:export.py --config test_tipc/configs/fastscnn/fastscnn_cityscapes_1024x1024_160k.yml
+norm_export:export.py --config test_tipc/configs/fastscnn/fastscnn_cityscapes.yml
 quant_export:null
 fpgm_export:null
 distill_export:null
@@ -35,7 +35,7 @@ export1:null
 export2:null
 ===========================infer_params===========================
 infer_model:./test_tipc/output/fastscnn/model.pdparams
-infer_export:export.py --config test_tipc/configs/fastscnn/fastscnn_cityscapes_1024x1024_160k.yml
+infer_export:export.py --config test_tipc/configs/fastscnn/fastscnn_cityscapes.yml
 infer_quant:False
 inference:deploy/python/infer.py
 --device:cpu|gpu

--- a/test_tipc/configs/fastscnn/train_infer_python.txt
+++ b/test_tipc/configs/fastscnn/train_infer_python.txt
@@ -1,19 +1,19 @@
 ===========================train_params===========================
-model_name:deeplabv3p_resnet50
+model_name:fastscnn
 python:python3.7
 gpu_list:0|0,1
 Global.use_gpu:null|null
 --precision:null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
---batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=8
+--batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=3
 Global.pretrained_model:null
 train_model_name:best_model/model.pdparams
-train_infer_img_dir:test_tipc/data/mini_supervisely/test.txt
+train_infer_img_dir:test_tipc/data/cityscapes/val.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/deeplabv3p_resnet50/deeplabv3p_resnet50_humanseg_512x512_mini_supervisely.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/fastscnn/fastscnn_cityscapes_1024x1024_160k.yml --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null
@@ -27,15 +27,15 @@ null:null
 ===========================export_params===========================
 --save_dir:
 --model_path:
-norm_export:export.py --config test_tipc/configs/deeplabv3p_resnet50/deeplabv3p_resnet50_humanseg_512x512_mini_supervisely.yml
+norm_export:export.py --config test_tipc/configs/fastscnn/fastscnn_cityscapes_1024x1024_160k.yml
 quant_export:null
 fpgm_export:null
 distill_export:null
 export1:null
 export2:null
 ===========================infer_params===========================
-infer_model:./test_tipc/output/deeplabv3p_resnet50/deeplabv3p_resnet50_os8_humanseg_512x512_100k/model.pdparams
-infer_export:export.py --config test_tipc/configs/deeplabv3p_resnet50/deeplabv3p_resnet50_humanseg_512x512_mini_supervisely.yml
+infer_model:./test_tipc/output/fastscnn/model.pdparams
+infer_export:export.py --config test_tipc/configs/fastscnn/fastscnn_cityscapes_1024x1024_160k.yml
 infer_quant:False
 inference:deploy/python/infer.py
 --device:cpu|gpu
@@ -45,8 +45,14 @@ inference:deploy/python/infer.py
 --use_trt:False|True
 --precision:fp32|int8|fp16
 --config:
---image_path:./test_tipc/data/mini_supervisely/test.txt
+--image_path:./test_tipc/data/cityscapes/val.list
 --save_log_path:null
 --benchmark:True
 --save_dir:
---model_name:deeplabv3p_resnet50
+--model_name:fastscnn
+===========================train_benchmark_params==========================
+batch_size:2|4
+fp_items:fp32
+epoch:50
+--profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
+flags:FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.98;FLAGS_conv_workspace_size_limit=4096

--- a/test_tipc/configs/fcn_hrnetw18/fcn_hrnetw18_1024x512_cityscapes.yml
+++ b/test_tipc/configs/fcn_hrnetw18/fcn_hrnetw18_1024x512_cityscapes.yml
@@ -1,0 +1,51 @@
+batch_size: 2
+iters: 80000
+to_static_training: False
+
+train_dataset:
+  type: Cityscapes
+  dataset_root: data/cityscapes
+  transforms:
+    - type: ResizeStepScaling
+      min_scale_factor: 0.5
+      max_scale_factor: 2.0
+      scale_step_size: 0.25
+    - type: RandomPaddingCrop
+      crop_size: [1024, 512]
+    - type: RandomHorizontalFlip
+    - type: RandomDistort
+    - type: Normalize
+  mode: train
+
+val_dataset:
+  type: Cityscapes
+  dataset_root: data/cityscapes
+  transforms:
+    - type: Normalize
+  mode: val
+
+model:
+  type: FCN
+  backbone:
+    type: HRNet_W18
+    pretrained: https://bj.bcebos.com/paddleseg/dygraph/hrnet_w18_ssld.tar.gz
+    padding_same: False
+  num_classes: 19
+  backbone_indices: [-1]
+  bias: False
+
+optimizer:
+  type: sgd
+  weight_decay: 0.0005
+
+lr_scheduler:
+  type: PolynomialDecay
+  learning_rate: 0.01
+  end_lr: 0
+  power: 0.9
+
+loss:
+  types:
+    - type: CrossEntropyLoss
+      ignore_index: 255
+  coef: [1]

--- a/test_tipc/configs/fcn_hrnetw18/train_infer_python.txt
+++ b/test_tipc/configs/fcn_hrnetw18/train_infer_python.txt
@@ -1,5 +1,5 @@
 ===========================train_params===========================
-model_name:deeplabv3p_resnet50
+model_name:fcn_hrnetw18
 python:python3.7
 gpu_list:0|0,1
 Global.use_gpu:null|null
@@ -9,11 +9,11 @@ Global.use_gpu:null|null
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=8
 Global.pretrained_model:null
 train_model_name:best_model/model.pdparams
-train_infer_img_dir:test_tipc/data/mini_supervisely/test.txt
+train_infer_img_dir:test_tipc/data/cityscapes/test.txt
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/deeplabv3p_resnet50/deeplabv3p_resnet50_humanseg_512x512_mini_supervisely.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/fcn_hrnetw18/fcn_hrnetw18_1024x512_cityscapes.yml --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null
@@ -27,15 +27,15 @@ null:null
 ===========================export_params===========================
 --save_dir:
 --model_path:
-norm_export:export.py --config test_tipc/configs/deeplabv3p_resnet50/deeplabv3p_resnet50_humanseg_512x512_mini_supervisely.yml
+norm_export:export.py --config test_tipc/configs/fcn_hrnetw18/fcn_hrnetw18_1024x512_cityscapes.yml
 quant_export:null
 fpgm_export:null
 distill_export:null
 export1:null
 export2:null
 ===========================infer_params===========================
-infer_model:./test_tipc/output/deeplabv3p_resnet50/deeplabv3p_resnet50_os8_humanseg_512x512_100k/model.pdparams
-infer_export:export.py --config test_tipc/configs/deeplabv3p_resnet50/deeplabv3p_resnet50_humanseg_512x512_mini_supervisely.yml
+infer_model:./test_tipc/output/fcn_hrnetw18/fcn_hrnetw18_1024x512/model.pdparams
+infer_export:export.py --config test_tipc/configs/fcn_hrnetw18/fcn_hrnetw18_1024x512_cityscapes.yml
 infer_quant:False
 inference:deploy/python/infer.py
 --device:cpu|gpu
@@ -45,8 +45,14 @@ inference:deploy/python/infer.py
 --use_trt:False|True
 --precision:fp32|int8|fp16
 --config:
---image_path:./test_tipc/data/mini_supervisely/test.txt
+--image_path:./test_tipc/data/cityscapes/test.txt
 --save_log_path:null
 --benchmark:True
 --save_dir:
---model_name:deeplabv3p_resnet50
+--model_name:fcn_hrnetw18
+===========================train_benchmark_params==========================
+batch_size:8
+fp_items:fp32|fp16
+epoch:50
+--profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
+flags:FLAGS_cudnn_exhaustive_search=1;FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.98;FLAGS_conv_workspace_size_limit=4096

--- a/test_tipc/configs/fcn_hrnetw18_small/train_infer_python.txt
+++ b/test_tipc/configs/fcn_hrnetw18_small/train_infer_python.txt
@@ -3,7 +3,7 @@ model_name:fcn_hrnetw18_small
 python:python3.7
 gpu_list:0|0,1
 Global.use_gpu:null|null
-Global.auto_cast:null
+--precision:null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=8

--- a/test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x1024.yml
+++ b/test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x1024.yml
@@ -1,0 +1,27 @@
+# The ocrnet_hrnetw48 config for train benchmark
+_base_: '../_base_/cityscapes_1024x1024.yml'
+
+batch_size: 2
+iters: 500
+
+model:
+  type: OCRNet
+  backbone:
+    type: HRNet_W48
+    pretrained: https://bj.bcebos.com/paddleseg/dygraph/hrnet_w48_ssld.tar.gz
+  num_classes: 19
+  backbone_indices: [0]
+
+optimizer:
+  type: sgd
+
+lr_scheduler:
+  type: PolynomialDecay
+  learning_rate: 0.01
+  power: 0.9
+
+loss:
+  types:
+    - type: CrossEntropyLoss
+    - type: CrossEntropyLoss
+  coef: [1, 0.4]

--- a/test_tipc/configs/ocrnet_hrnetw48/train_infer_python.txt
+++ b/test_tipc/configs/ocrnet_hrnetw48/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/val.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x512_160k.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x1024.yml --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null
@@ -27,7 +27,7 @@ null:null
 ===========================export_params===========================
 --save_dir:
 --model_path:
-norm_export:export.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x512_160k.yml
+norm_export:export.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x1024.yml
 quant_export:null
 fpgm_export:null
 distill_export:null
@@ -35,7 +35,7 @@ export1:null
 export2:null
 ===========================infer_params===========================
 infer_model:./test_tipc/output/ocrnet_hrnetw48/model.pdparams
-infer_export:export.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x512_160k.yml
+infer_export:export.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x1024.yml
 infer_quant:False
 inference:deploy/python/infer.py
 --device:cpu|gpu

--- a/test_tipc/configs/ocrnet_hrnetw48/train_infer_python.txt
+++ b/test_tipc/configs/ocrnet_hrnetw48/train_infer_python.txt
@@ -1,5 +1,5 @@
 ===========================train_params===========================
-model_name:ocrnet_hrnetw18
+model_name:ocrnet_hrnetw48
 python:python3.7
 gpu_list:0|0,1
 Global.use_gpu:null|null
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/val.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/ocrnet_hrnetw18/ocrnet_hrnetw18_cityscapes_1024x512_160k.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x512_160k.yml --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null
@@ -27,15 +27,15 @@ null:null
 ===========================export_params===========================
 --save_dir:
 --model_path:
-norm_export:export.py --config test_tipc/configs/ocrnet_hrnetw18/ocrnet_hrnetw18_cityscapes_1024x512_160k.yml
+norm_export:export.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x512_160k.yml
 quant_export:null
 fpgm_export:null
 distill_export:null
 export1:null
 export2:null
 ===========================infer_params===========================
-infer_model:./test_tipc/output/ocrnet_hrnetw18/model.pdparams
-infer_export:export.py --config test_tipc/configs/ocrnet_hrnetw18/ocrnet_hrnetw18_cityscapes_1024x512_160k.yml
+infer_model:./test_tipc/output/ocrnet_hrnetw48/model.pdparams
+infer_export:export.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x512_160k.yml
 infer_quant:False
 inference:deploy/python/infer.py
 --device:cpu|gpu
@@ -49,4 +49,10 @@ inference:deploy/python/infer.py
 --save_log_path:null
 --benchmark:True
 --save_dir:
---model_name:ocrnet_hrnetw18
+--model_name:ocrnet_hrnetw48
+===========================train_benchmark_params==========================
+batch_size:2|4
+fp_items:fp32
+epoch:50
+--profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
+flags:FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.98;FLAGS_conv_workspace_size_limit=4096

--- a/test_tipc/configs/pfpnnet/train_infer_python.txt
+++ b/test_tipc/configs/pfpnnet/train_infer_python.txt
@@ -3,7 +3,7 @@ model_name:pfpnnet
 python:python3.7
 gpu_list:0|0,1
 Global.use_gpu:null|null
-Global.auto_cast:null
+--precision:null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=3

--- a/test_tipc/configs/ppmatting/train_infer_python.txt
+++ b/test_tipc/configs/ppmatting/train_infer_python.txt
@@ -3,7 +3,7 @@ model_name:ppmatting
 python:python3.7
 gpu_list:0|0,1
 Global.use_gpu:null|null
-Global.auto_cast:null
+--precision:null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=8

--- a/test_tipc/configs/segformer_b0/train_infer_python.txt
+++ b/test_tipc/configs/segformer_b0/train_infer_python.txt
@@ -3,7 +3,7 @@ model_name:segformer_b0
 python:python3.7
 gpu_list:0|0,1
 Global.use_gpu:null|null
-Global.auto_cast:null
+--precision:null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=3
@@ -50,3 +50,9 @@ inference:deploy/python/infer.py
 --benchmark:True
 --save_dir:
 --model_name:segformer_b0
+===========================train_benchmark_params==========================
+batch_size:2|4
+fp_items:fp32
+epoch:50
+--profiler_options:batch_range=[10,20];state=GPU;tracer_option=Default;profile_path=model.profile
+flags:FLAGS_eager_delete_tensor_gb=0.0;FLAGS_fraction_of_gpu_memory_to_use=0.98;FLAGS_conv_workspace_size_limit=4096

--- a/test_tipc/configs/stdc_stdc1/train_infer_python.txt
+++ b/test_tipc/configs/stdc_stdc1/train_infer_python.txt
@@ -3,7 +3,7 @@ model_name:stdc_stdc1
 python:python3.7
 gpu_list:0|0,1
 Global.use_gpu:null|null
-Global.auto_cast:null
+--precision:null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=8

--- a/test_tipc/docs/benchmark_train.md
+++ b/test_tipc/docs/benchmark_train.md
@@ -1,0 +1,53 @@
+
+# TIPC Linux端Benchmark测试文档
+
+该文档为Benchmark测试说明，Benchmark预测功能测试的主程序为`benchmark_train.sh`，用于验证监控模型训练的性能。
+
+# 1. 测试流程
+## 1.1 准备数据和环境安装
+运行`test_tipc/prepare.sh`，完成训练数据准备和安装环境流程。
+
+```shell
+# 运行格式：bash test_tipc/prepare.sh  train_infer_python.txt  mode
+bash test_tipc/prepare.sh test_tipc/configs/segformer_b0/train_infer_python.txt benchmark_train
+```
+
+## 1.2 功能测试
+执行`test_tipc/benchmark_train.sh`，完成模型训练和日志解析
+
+```shell
+# 运行格式：bash test_tipc/benchmark_train.sh train_infer_python.txt mode
+bash test_tipc/benchmark_train.sh test_tipc/configs/segformer_b0/train_infer_python.txt benchmark_train
+
+```
+
+`test_tipc/benchmark_train.sh`支持根据传入的第三个参数实现只运行某一个训练配置，如下：
+```shell
+# 运行格式：bash test_tipc/benchmark_train.sh train_infer_python.txt mode
+bash test_tipc/benchmark_train.sh test_tipc/configs/segformer_b0/train_infer_python.txt benchmark_train  dynamic_bs2_fp32_DP_N1C1
+```
+dynamic_bs2_fp32_DP_N1C1为test_tipc/benchmark_train.sh传入的参数，格式如下：
+`${modeltype}_${batch_size}_${fp_item}_${run_mode}_${device_num}`
+包含的信息有：模型类型、batchsize大小、训练精度如fp32,fp16等、分布式运行模式以及分布式训练使用的机器信息如单机单卡（N1C1）。
+
+
+## 2. 日志输出
+
+运行后将保存模型的训练日志和解析日志，使用 `test_tipc/configs/segformer_b0/train_infer_python.txt` 参数文件的训练日志解析结果是：
+
+```
+{"model_branch": "dygaph", "model_commit": "7c39a1996b19087737c05d883fd346d2f39dbcc0", "model_name": "segformer_b0_bs2_fp32_SingleP_DP", "batch_size": 8, "fp_item": "fp32", "run_process_type": "SingleP", "run_mode": "DP", "convergence_value": "5.413110", "convergence_key": "loss:", "ips": 19.333, "speed_unit": "samples/s", "device_num": "N1C1", "model_run_time": "0", "frame_commit": "8cc09552473b842c651ead3b9848d41827a3dbab", "frame_version": "0.0.0"}
+```
+
+训练日志和日志解析结果保存在benchmark_log目录下，文件组织格式如下：
+```
+train_log/
+├── index
+│   ├── PaddleSeg_segformer_b0_bs2_fp32_SingleP_DP_N1C1_speed
+│   └── PaddleSeg_segformer_b0_bs2_fp32_SingleP_DP_N1C4_speed
+├── profiling_log
+│   └── PaddleSeg_segformer_b0_bs2_fp32_SingleP_DP_N1C1_profiling
+└── train_log
+    ├── PaddleSeg_segformer_b0_bs2_fp32_SingleP_DP_N1C1_log
+    └── PaddleSeg_segformer_b0_bs2_fp32_SingleP_DP_N1C4_log
+```

--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -45,18 +45,28 @@ if [ ${MODE} = "whole_infer" ] || [ ${MODE} = "klquant_whole_infer" ]; then
         wget -nc -P $model_path https://paddleseg.bj.bcebos.com/matting/models/modnet-mobilenetv2.pdparams
     fi
 fi
-# download data
-if [ ${model_name} == "fcn_hrnetw18_small" ] || [ ${model_name} == "pphumanseg_lite" ] || [ ${model_name} == "deeplabv3p_resnet50" ];then
-    rm -rf ./test_tipc/data/mini_supervisely
-    wget -nc -P ./test_tipc/data/ https://paddleseg.bj.bcebos.com/humanseg/data/mini_supervisely.zip
-    cd ./test_tipc/data/ && unzip mini_supervisely.zip && cd -
-elif [ ${model_name} == "ocrnet_hrnetw18" ] || [ ${model_name} == "bisenetv2" ] || [ ${model_name} == "segformer_b0" ] || [ ${model_name} == "stdc_stdc1" ] || [ ${model_name} == "pfpnnet" ];then
-    rm -rf ./test_tipc/data/cityscapes
-    wget -nc -P ./test_tipc/data/ https://paddleseg.bj.bcebos.com/dataset/cityscapes.tar
-    cd ./test_tipc/data/ && tar -xvf cityscapes.tar && cd -
-elif [ ${model_name} == "ppmatting" ];then
-    rm -rf ./test_tipc/data/PPM-100
-    wget -nc -P ./test_tipc/data/ https://paddleseg.bj.bcebos.com/matting/datasets/PPM-100.zip
-    cd ./test_tipc/data/ && unzip PPM-100.zip && cd -
 
+# download data
+if [ ${MODE} = "benchmark_train" ];then
+    pip install -r requirements.txt
+    mkdir -p ./test_tipc/data
+    wget https://paddleseg.bj.bcebos.com/dataset/cityscapes_30imgs.tar.gz \
+        -O ./test_tipc/data/cityscapes_30imgs.tar.gz
+    tar -zxf ./test_tipc/data/cityscapes_30imgs.tar.gz -C ./test_tipc/data/
+    mv ./test_tipc/data/cityscapes_30imgs ./test_tipc/data/cityscapes
+else
+    if [ ${model_name} == "fcn_hrnetw18_small" ] || [ ${model_name} == "pphumanseg_lite" ] || [ ${model_name} == "deeplabv3p_resnet50" ];then
+        rm -rf ./test_tipc/data/mini_supervisely
+        wget -nc -P ./test_tipc/data/ https://paddleseg.bj.bcebos.com/humanseg/data/mini_supervisely.zip
+        cd ./test_tipc/data/ && unzip mini_supervisely.zip && cd -
+    elif [ ${model_name} == "ocrnet_hrnetw18" ] || [ ${model_name} == "bisenetv2" ] || [ ${model_name} == "segformer_b0" ] || [ ${model_name} == "stdc_stdc1" ] || [ ${model_name} == "pfpnnet" ];then
+        rm -rf ./test_tipc/data/cityscapes
+        wget -nc -P ./test_tipc/data/ https://paddleseg.bj.bcebos.com/dataset/cityscapes.tar
+        cd ./test_tipc/data/ && tar -xvf cityscapes.tar && cd -
+    elif [ ${model_name} == "ppmatting" ];then
+        rm -rf ./test_tipc/data/PPM-100
+        wget -nc -P ./test_tipc/data/ https://paddleseg.bj.bcebos.com/matting/datasets/PPM-100.zip
+        cd ./test_tipc/data/ && unzip PPM-100.zip && cd -
+
+    fi
 fi

--- a/train.py
+++ b/train.py
@@ -99,7 +99,13 @@ def parse_args():
         default=None,
         type=int)
     parser.add_argument(
-        '--fp16', dest='fp16', help='Whther to use amp', action='store_true')
+        "--precision",
+        default="precision",
+        type=str,
+        choices=["fp32", "fp16"],
+        help=
+        "Use AMP if precision='fp16'. If precision='fp32', the training is normal."
+    )
     parser.add_argument(
         '--data_format',
         dest='data_format',
@@ -189,7 +195,7 @@ def main(args):
         losses=losses,
         keep_checkpoint_max=args.keep_checkpoint_max,
         test_config=cfg.test_config,
-        fp16=args.fp16,
+        precision=args.precision,
         profiler_options=args.profiler_options,
         to_static_training=cfg.to_static_training)
 

--- a/train.py
+++ b/train.py
@@ -100,7 +100,7 @@ def parse_args():
         type=int)
     parser.add_argument(
         "--precision",
-        default="precision",
+        default="fp32",
         type=str,
         choices=["fp32", "fp16"],
         help=


### PR DESCRIPTION
1 benchmark流水线接入TIPC
2 接入5个benchmark动态图模型
3 为适配TIPC，PaddleSeg 训练脚本 --fp16修改为--precision，原版benchmark脚本同步修改
4 修复特殊情况下PaddleSeg评估失败的问题。特殊情况指无评估集的情况。
![844886d7d610da355adc849dc197410d](https://user-images.githubusercontent.com/30695251/155104855-42181797-0045-4f53-8ee3-dbbff51da9d6.png)
