### PR TITLE
[Fix] Update binary_cross_entropy_loss.py

### DIFF
--- a/paddleseg/models/losses/binary_cross_entropy_loss.py
+++ b/paddleseg/models/losses/binary_cross_entropy_loss.py
@@ -99,7 +99,7 @@ class BCELoss(nn.Layer):
                     raise ValueError(
                         "if type of `weight` is str, it should equal to 'dynamic', but it is {}"
                         .format(self.weight))
-            elif isinstance(self.weight, paddle.VarBase):
+            elif isinstance(self.weight, paddle.Tensor):
                 raise TypeError(
                     'The type of `weight` is wrong, it should be Tensor or str, but it is {}'
                     .format(type(self.weight)))


### PR DESCRIPTION
fixed "AttributeError: module 'paddle' has no attribute 'VarBase'".