### PR TITLE
[TIPC] Fix the problem of degraded training performance. TIPC basic chain supports pure evaluation mode

### DIFF
--- a/test_tipc/configs/bisenetv2/train_infer_python.txt
+++ b/test_tipc/configs/bisenetv2/train_infer_python.txt
@@ -7,7 +7,7 @@ Global.use_gpu:null|null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=3
-Global.pretrained_model:null
+--model_path:null
 train_model_name:best_model/model.pdparams
 train_infer_img_dir:test_tipc/data/cityscapes/val.list
 null:null

--- a/test_tipc/configs/deeplabv3p_resnet50/train_infer_python.txt
+++ b/test_tipc/configs/deeplabv3p_resnet50/train_infer_python.txt
@@ -7,7 +7,7 @@ Global.use_gpu:null|null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=8
-Global.pretrained_model:null
+--model_path:null
 train_model_name:best_model/model.pdparams
 train_infer_img_dir:test_tipc/data/mini_supervisely/test.txt
 null:null

--- a/test_tipc/configs/deeplabv3p_resnet50_cityscapes/train_infer_python.txt
+++ b/test_tipc/configs/deeplabv3p_resnet50_cityscapes/train_infer_python.txt
@@ -7,7 +7,7 @@ Global.use_gpu:null|null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=8
-Global.pretrained_model:null
+--model_path:null
 train_model_name:best_model/model.pdparams
 train_infer_img_dir:test_tipc/data/cityscapes/test.txt
 null:null

--- a/test_tipc/configs/deeplabv3p_resnet50_cityscapes/train_infer_python.txt
+++ b/test_tipc/configs/deeplabv3p_resnet50_cityscapes/train_infer_python.txt
@@ -21,7 +21,7 @@ null:null
 null:null
 ##
 ===========================eval_params===========================
-eval:null
+eval:val.py .py --config test_tipc/configs/deeplabv3p_resnet50_cityscapes/deeplabv3p_resnet50_1024x512_cityscapes.yml --num_workers 8
 null:null
 ##
 ===========================export_params===========================

--- a/test_tipc/configs/enet/train_infer_python.txt
+++ b/test_tipc/configs/enet/train_infer_python.txt
@@ -7,7 +7,7 @@ Global.auto_cast:null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=3
-Global.pretrained_model:null
+--model_path:null
 train_model_name:best_model/model.pdparams
 train_infer_img_dir:test_tipc/data/cityscapes/val.list
 null:null

--- a/test_tipc/configs/fastscnn/train_infer_python.txt
+++ b/test_tipc/configs/fastscnn/train_infer_python.txt
@@ -7,7 +7,7 @@ Global.use_gpu:null|null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=3
-Global.pretrained_model:null
+--model_path:null
 train_model_name:best_model/model.pdparams
 train_infer_img_dir:test_tipc/data/cityscapes/val.list
 null:null

--- a/test_tipc/configs/fastscnn/train_infer_python.txt
+++ b/test_tipc/configs/fastscnn/train_infer_python.txt
@@ -21,7 +21,7 @@ null:null
 null:null
 ##
 ===========================eval_params===========================
-eval:null
+eval:val.py --config test_tipc/configs/fastscnn/fastscnn_cityscapes.yml --num_workers 8
 null:null
 ##
 ===========================export_params===========================

--- a/test_tipc/configs/fcn_hrnetw18/train_infer_python.txt
+++ b/test_tipc/configs/fcn_hrnetw18/train_infer_python.txt
@@ -7,7 +7,7 @@ Global.use_gpu:null|null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=8
-Global.pretrained_model:null
+--model_path:null
 train_model_name:best_model/model.pdparams
 train_infer_img_dir:test_tipc/data/cityscapes/test.txt
 null:null

--- a/test_tipc/configs/fcn_hrnetw18/train_infer_python.txt
+++ b/test_tipc/configs/fcn_hrnetw18/train_infer_python.txt
@@ -21,7 +21,7 @@ null:null
 null:null
 ##
 ===========================eval_params===========================
-eval:null
+eval:val.py --config test_tipc/configs/fcn_hrnetw18/fcn_hrnetw18_1024x512_cityscapes.yml --num_workers 8
 null:null
 ##
 ===========================export_params===========================

--- a/test_tipc/configs/fcn_hrnetw18_small/train_infer_python.txt
+++ b/test_tipc/configs/fcn_hrnetw18_small/train_infer_python.txt
@@ -7,7 +7,7 @@ Global.use_gpu:null|null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=8
-Global.pretrained_model:null
+--model_path:null
 train_model_name:best_model/model.pdparams
 train_infer_img_dir:test_tipc/data/mini_supervisely/test.txt
 null:null

--- a/test_tipc/configs/ocrnet_hrnetw18/train_infer_python.txt
+++ b/test_tipc/configs/ocrnet_hrnetw18/train_infer_python.txt
@@ -7,7 +7,7 @@ Global.use_gpu:null|null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=3
-Global.pretrained_model:null
+--model_path:null
 train_model_name:best_model/model.pdparams
 train_infer_img_dir:test_tipc/data/cityscapes/val.list
 null:null

--- a/test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x512.yml
+++ b/test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x512.yml
@@ -1,5 +1,5 @@
 # The ocrnet_hrnetw48 config for train benchmark
-_base_: '../_base_/cityscapes_1024x1024.yml'
+_base_: '../_base_/cityscapes.yml'
 
 batch_size: 2
 iters: 500

--- a/test_tipc/configs/ocrnet_hrnetw48/train_infer_python.txt
+++ b/test_tipc/configs/ocrnet_hrnetw48/train_infer_python.txt
@@ -7,13 +7,13 @@ Global.use_gpu:null|null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=3
-Global.pretrained_model:null
+--model_path:null
 train_model_name:best_model/model.pdparams
 train_infer_img_dir:test_tipc/data/cityscapes/val.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x1024.yml  --save_interval 500 --seed 100 --num_workers 8
+norm_train:train.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x512.yml --save_interval 500 --seed 100  --num_workers 8
 pact_train:null
 fpgm_train:null
 distill_train:null
@@ -21,13 +21,13 @@ null:null
 null:null
 ##
 ===========================eval_params===========================
-eval:null
+eval:val.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x512.yml --num_workers 8
 null:null
 ##
 ===========================export_params===========================
 --save_dir:
 --model_path:
-norm_export:export.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x1024.yml
+norm_export:export.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x512.yml
 quant_export:null
 fpgm_export:null
 distill_export:null
@@ -35,7 +35,7 @@ export1:null
 export2:null
 ===========================infer_params===========================
 infer_model:./test_tipc/output/ocrnet_hrnetw48/model.pdparams
-infer_export:export.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x1024.yml
+infer_export:export.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x512.yml
 infer_quant:False
 inference:deploy/python/infer.py
 --device:cpu|gpu

--- a/test_tipc/configs/pfpnnet/train_infer_python.txt
+++ b/test_tipc/configs/pfpnnet/train_infer_python.txt
@@ -7,7 +7,7 @@ Global.use_gpu:null|null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=3
-Global.pretrained_model:null
+--model_path:null
 train_model_name:best_model/model.pdparams
 train_infer_img_dir:test_tipc/data/cityscapes/val.list
 null:null

--- a/test_tipc/configs/pphumanseg_lite/train_infer_python.txt
+++ b/test_tipc/configs/pphumanseg_lite/train_infer_python.txt
@@ -7,7 +7,7 @@ Global.auto_cast:null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=8
-Global.pretrained_model:null
+--model_path:null
 train_model_name:best_model/model.pdparams
 train_infer_img_dir:test_tipc/data/mini_supervisely/test.txt
 null:null

--- a/test_tipc/configs/ppmatting/train_infer_python.txt
+++ b/test_tipc/configs/ppmatting/train_infer_python.txt
@@ -7,7 +7,7 @@ Global.use_gpu:null|null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=8
-Global.pretrained_model:null
+--model_path:null
 train_model_name:best_model/model.pdparams
 train_infer_img_dir:test_tipc/data/PPM-100/val.txt
 null:null

--- a/test_tipc/configs/segformer_b0/train_infer_python.txt
+++ b/test_tipc/configs/segformer_b0/train_infer_python.txt
@@ -7,7 +7,7 @@ Global.use_gpu:null|null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=3
-Global.pretrained_model:null
+--model_path:null
 train_model_name:best_model/model.pdparams
 train_infer_img_dir:test_tipc/data/cityscapes/val.list
 null:null

--- a/test_tipc/configs/segformer_b0/train_infer_python.txt
+++ b/test_tipc/configs/segformer_b0/train_infer_python.txt
@@ -21,7 +21,7 @@ null:null
 null:null
 ##
 ===========================eval_params===========================
-eval:null
+eval:val.py --config test_tipc/configs/segformer_b0/segformer_b0_cityscapes_1024x1024_160k.yml --num_workers 8
 null:null
 ##
 ===========================export_params===========================

--- a/test_tipc/configs/stdc_stdc1/train_infer_python.txt
+++ b/test_tipc/configs/stdc_stdc1/train_infer_python.txt
@@ -7,7 +7,7 @@ Global.use_gpu:null|null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000
 --save_dir:
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=8
-Global.pretrained_model:null
+--model_path:null
 train_model_name:best_model/model.pdparams
 train_infer_img_dir:test_tipc/data/cityscapes/val.list
 null:null

--- a/test_tipc/test_train_inference_python.sh
+++ b/test_tipc/test_train_inference_python.sh
@@ -343,6 +343,10 @@ else
                 eval $cmd
                 status_check $? "${cmd}" "${status_log}"
 
+                # modify model dir if no eval
+                if [ ! -f "${save_log}/${train_model_name}" ]; then
+                    train_model_name="iter_${epoch_num}/model.pdparams"
+                fi
                 set_eval_pretrain=$(func_set_params "${pretrain_model_key}" "${save_log}/${train_model_name}")
                 # save norm trained models to set pretrain for pact training and fpgm training
                 if [ ${trainer} = ${trainer_norm} ] && [ ${nodes} -le 1]; then


### PR DESCRIPTION
1 修复HRNet、DeepLabV3p、OCRNet训练性能下降的问题
2 TIPC基础链条支持纯评估模式，与训练模式解耦


benchmark模型迁移，修复迁移后的脚本问题引起的性能下降（环境：V100 32g ）

1、deeplabv3p_resnet50_bs4_fp32(samples/s) 单卡性能： 3.361 ->5.8 （num_workers=8 ）
由于使用的小数据集，与旧benchmark仍存在diff（旧系统中使用12G cityscapes：6.15）,已更换为大数据集

2、ocrnet_hrnetw48_bs2_fp32(samples/s) ：2.202->2.43 （num_workers=8 ）
由于跟就系统中yaml 不一致，仍然存在diff （旧系统中使用benchmark/configs/ocrnet_hrnetw48.yml ：3.248）

3、fcn_hrnetw18_bs8_fp32(samples/s)：5.31->8.066 （num_workers=8 ）
由于使用的小数据集，与旧benchmark仍存在diff（旧系统中使用12G cityscapes：17.125），已更换为大数据集

4、segformer_b0_bs2_fp32(samples/s) : 3.986 -> 8.234 （num_workers=8 ） 优于旧系统中：7.76

5、fastscnn_bs2_fp32(samples/s) ： 4.386 -> 18.676（num_workers=8 ）优于旧系统中：17.147