### PR TITLE
[NPU] add NPU support

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -106,7 +106,7 @@ def parse_args():
     parser.add_argument(
         '--device',
         dest='device',
-        help='Device place to be set, which can be GPU, XPU, CPU',
+        help='Device place to be set, which can be GPU, XPU, NPU, CPU',
         default='gpu',
         type=str)
 

--- a/predict.py
+++ b/predict.py
@@ -101,6 +101,15 @@ def parse_args():
         help='Save images with a custom color map. Default: None, use paddleseg\'s default color map.',
         type=int,
         default=None)
+
+    # set device
+    parser.add_argument(
+        '--device',
+        dest='device',
+        help='Device place to be set, which can be GPU, XPU, CPU',
+        default='gpu',
+        type=str)
+
     return parser.parse_args()
 
 
@@ -130,8 +139,16 @@ def get_test_config(cfg, args):
 
 def main(args):
     env_info = get_sys_env()
-    place = 'gpu' if env_info['Paddle compiled with cuda'] and env_info[
-        'GPUs used'] else 'cpu'
+
+    if args.device == 'gpu' and env_info[
+            'Paddle compiled with cuda'] and env_info['GPUs used']:
+        place = 'gpu'
+    elif args.device == 'xpu' and paddle.is_compiled_with_xpu():
+        place = 'xpu'
+    elif args.device == 'npu' and paddle.is_compiled_with_npu():
+        place = 'npu'
+    else:
+        place = 'cpu'
 
     paddle.set_device(place)
     if not args.cfg:

--- a/train.py
+++ b/train.py
@@ -121,7 +121,7 @@ def parse_args():
     parser.add_argument(
         '--device',
         dest='device',
-        help='Device place to be set, which can be GPU, XPU, CPU',
+        help='Device place to be set, which can be GPU, XPU, NPU, CPU',
         default='gpu',
         type=str)
 

--- a/train.py
+++ b/train.py
@@ -146,6 +146,8 @@ def main(args):
         place = 'gpu'
     elif args.device == 'xpu' and paddle.is_compiled_with_xpu():
         place = 'xpu'
+    elif args.device == 'npu' and paddle.is_compiled_with_npu():
+        place = 'npu'
     else:
         place = 'cpu'
 

--- a/val.py
+++ b/val.py
@@ -117,13 +117,28 @@ def parse_args():
         type=bool,
         default=False)
 
+    parser.add_argument(
+        '--device',
+        dest='device',
+        help='Device place to be set, which can be GPU, XPU, CPU',
+        default='gpu',
+        type=str)
+
     return parser.parse_args()
 
 
 def main(args):
     env_info = get_sys_env()
-    place = 'gpu' if env_info['Paddle compiled with cuda'] and env_info[
-        'GPUs used'] else 'cpu'
+
+    if args.device == 'gpu' and env_info[
+            'Paddle compiled with cuda'] and env_info['GPUs used']:
+        place = 'gpu'
+    elif args.device == 'xpu' and paddle.is_compiled_with_xpu():
+        place = 'xpu'
+    elif args.device == 'npu' and paddle.is_compiled_with_npu():
+        place = 'npu'
+    else:
+        place = 'cpu'
 
     paddle.set_device(place)
     if not args.cfg:

--- a/val.py
+++ b/val.py
@@ -120,7 +120,7 @@ def parse_args():
     parser.add_argument(
         '--device',
         dest='device',
-        help='Device place to be set, which can be GPU, XPU, CPU',
+        help='Device place to be set, which can be GPU, XPU, NPU, CPU',
         default='gpu',
         type=str)
 


### PR DESCRIPTION
[NPU] add NPU support

在 CUDA 和 NPU 环境分别测试了 train.py, val.py, predict.py 的训练、评估、预测功能，是正常的。

XPU 没有环境跑，这里顺带的一起改了一下，是否需要却掉 XPU 的修改？