### PR TITLE
[TIPC] Add deeplabv3p_resnet50_cityscapes, fastscnn, hrnetw18, ocrnet_hrnetw48 for basic chain. Fix ppmatting, enet bugs

### DIFF
--- a/test_tipc/README.md
+++ b/test_tipc/README.md
@@ -23,16 +23,20 @@
 
 | 算法论文 | 模型名称 | 基础<br>训练预测 | 更多<br>训练方式 | 模型压缩 |  其他预测部署  |
 | :--- | :--- |  :----:  |  :----  |   :----  |   :----  |
-| DeepLabv3p     |PP-HumanSeg-Server (DeepLabv3p_resnet50) | 支持 | 混合精度 | - | - |
 | HRNet     |PP-HumanSeg-Mobile (HRNet_W18_small)    | 支持  | 混合精度 | - | - |
+| HRNet     |HRNet_W18    | 支持  | - | - | - |
+| DeepLabv3p     |PP-HumanSeg-Server (DeepLabv3p_resnet50) | 支持 | 混合精度 | - | - |
+| DeepLabv3p     |DeepLabv3p_resnet50_cityscapes | 支持 | - | - | - |
 | ConnectNet | PP-HumanSeg-Lite | 支持 | - | - | - |
 | BiSeNetV2 | BiSeNetV2 | 支持 | - | - | - |
 | OCRNet | OCRNet_HRNetW18 | 支持 | - | - | - |
+| OCRNet | OCRNet_HRNetW48 | 支持 | - | - | - |
 | Segformer | Segformer_B0 | 支持 | - | - | - |
 | STDC | STDC_STDC1 | 支持 | - | - | - |
 | MODNet | PP-Matting | 支持 | - | - | - |
 | PFPNNet | PFPNNet | 支持 | - | - | - |
 | ENet | ENet | 支持 | - | - | - |
+| FastSCNN | FastSCNN | 支持 | - | - | - |
 
 
 ## 3. 测试工具简介

--- a/test_tipc/configs/deeplabv3p_resnet50_cityscapes/train_infer_python.txt
+++ b/test_tipc/configs/deeplabv3p_resnet50_cityscapes/train_infer_python.txt
@@ -9,7 +9,7 @@ Global.use_gpu:null|null
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=8
 --model_path:null
 train_model_name:best_model/model.pdparams
-train_infer_img_dir:test_tipc/data/cityscapes/test.txt
+train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
@@ -21,7 +21,7 @@ null:null
 null:null
 ##
 ===========================eval_params===========================
-eval:val.py .py --config test_tipc/configs/deeplabv3p_resnet50_cityscapes/deeplabv3p_resnet50_1024x512_cityscapes.yml --num_workers 8
+eval:val.py --config test_tipc/configs/deeplabv3p_resnet50_cityscapes/deeplabv3p_resnet50_1024x512_cityscapes.yml --num_workers 8
 null:null
 ##
 ===========================export_params===========================
@@ -45,7 +45,7 @@ inference:deploy/python/infer.py
 --use_trt:False|True
 --precision:fp32|int8|fp16
 --config:
---image_path:./test_tipc/data/cityscapes/test.txt
+--image_path:./test_tipc/data/cityscapes/cityscapes_val_5.list
 --save_log_path:null
 --benchmark:True
 --save_dir:

--- a/test_tipc/configs/enet/train_infer_python.txt
+++ b/test_tipc/configs/enet/train_infer_python.txt
@@ -1,7 +1,7 @@
 ===========================train_params===========================
 model_name:enet
-python:python3.8
-gpu_list:4|4,5
+python:python3.7
+gpu_list:0|0,1
 Global.use_gpu:null|null
 Global.auto_cast:null
 --iters:lite_train_lite_infer=50|lite_train_whole_infer=50|whole_train_whole_infer=1000

--- a/test_tipc/configs/fastscnn/train_infer_python.txt
+++ b/test_tipc/configs/fastscnn/train_infer_python.txt
@@ -9,7 +9,7 @@ Global.use_gpu:null|null
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=3
 --model_path:null
 train_model_name:best_model/model.pdparams
-train_infer_img_dir:test_tipc/data/cityscapes/val.list
+train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
@@ -45,7 +45,7 @@ inference:deploy/python/infer.py
 --use_trt:False|True
 --precision:fp32|int8|fp16
 --config:
---image_path:./test_tipc/data/cityscapes/val.list
+--image_path:./test_tipc/data/cityscapes/cityscapes_val_5.list
 --save_log_path:null
 --benchmark:True
 --save_dir:

--- a/test_tipc/configs/fcn_hrnetw18/train_infer_python.txt
+++ b/test_tipc/configs/fcn_hrnetw18/train_infer_python.txt
@@ -9,7 +9,7 @@ Global.use_gpu:null|null
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=8
 --model_path:null
 train_model_name:best_model/model.pdparams
-train_infer_img_dir:test_tipc/data/cityscapes/test.txt
+train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
@@ -45,7 +45,7 @@ inference:deploy/python/infer.py
 --use_trt:False|True
 --precision:fp32|int8|fp16
 --config:
---image_path:./test_tipc/data/cityscapes/test.txt
+--image_path:./test_tipc/data/cityscapes/cityscapes_val_5.list
 --save_log_path:null
 --benchmark:True
 --save_dir:

--- a/test_tipc/configs/ocrnet_hrnetw48/train_infer_python.txt
+++ b/test_tipc/configs/ocrnet_hrnetw48/train_infer_python.txt
@@ -9,7 +9,7 @@ Global.use_gpu:null|null
 --batch_size:lite_train_lite_infer=2|lite_train_whole_infer=2|whole_train_whole_infer=3
 --model_path:null
 train_model_name:best_model/model.pdparams
-train_infer_img_dir:test_tipc/data/cityscapes/val.list
+train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
@@ -45,7 +45,7 @@ inference:deploy/python/infer.py
 --use_trt:False
 --precision:fp32|int8|fp16
 --config:
---image_path:./test_tipc/data/cityscapes/val.list
+--image_path:./test_tipc/data/cityscapes/cityscapes_val_5.list
 --save_log_path:null
 --benchmark:True
 --save_dir:

--- a/test_tipc/configs/ppmatting/train_infer_python.txt
+++ b/test_tipc/configs/ppmatting/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/PPM-100/val.txt
 null:null
 ##
 trainer:norm
-norm_train:contrib/Matting/train.py --config test_tipc/configs/ppmatting/modnet_mobilenetv2.yml --do_eval --save_interval 500 --seed 100
+norm_train:Matting/train.py --config test_tipc/configs/ppmatting/modnet_mobilenetv2.yml --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null
@@ -27,7 +27,7 @@ null:null
 ===========================export_params===========================
 --save_dir:
 --model_path:
-norm_export:contrib/Matting/export.py --config test_tipc/configs/ppmatting/modnet_mobilenetv2.yml
+norm_export:Matting/export.py --config test_tipc/configs/ppmatting/modnet_mobilenetv2.yml
 quant_export:null
 fpgm_export:null
 distill_export:null
@@ -35,9 +35,9 @@ export1:null
 export2:null
 ===========================infer_params===========================
 infer_model:./test_tipc/output/ppmatting/modnet-mobilenetv2.pdparams
-infer_export:contrib/Matting/export.py --config test_tipc/configs/ppmatting/modnet_mobilenetv2.yml
+infer_export:Matting/export.py --config test_tipc/configs/ppmatting/modnet_mobilenetv2.yml
 infer_quant:False
-inference:contrib/Matting/deploy/python/infer.py
+inference:Matting/deploy/python/infer.py
 --device:cpu|gpu
 --enable_mkldnn:True|False
 --cpu_threads:1|6

--- a/test_tipc/docs/test_train_inference_python.md
+++ b/test_tipc/docs/test_train_inference_python.md
@@ -9,16 +9,20 @@ Linux端基础训练预测功能测试的主程序为`test_train_inference_pytho
 
 | 算法名称 | 模型名称 | 单机单卡 | 单机多卡 | 多机多卡 | 模型压缩（单机多卡） |
 |  :----  |   :----  |    :----  |  :----   |  :----   |  :----   |
-| DeepLabv3p     |PP-HumanSeg-Server (DeepLabv3p_resnet50)| 正常训练 <br> 混合精度 | 正常训练 <br> 混合精度 |  |  |
 |  HRNet     |PP-HumanSeg-mobile (HRNet_W18_small)  |  正常训练 <br> 混合精度 | 正常训练 <br> 混合精度 |  |  |
+| HRNet     |HRNet_W18| 正常训练 | 正常训练 |  |  |
+| DeepLabv3p     |PP-HumanSeg-Server (DeepLabv3p_resnet50)| 正常训练 <br> 混合精度 | 正常训练 <br> 混合精度 |  |  |
+| DeepLabv3p     |DeepLabv3p_resnet50_cityscapes| 正常训练 | 正常训练 |  |  |
 | ConnectNet | PP-HumanSeg-Lite| 正常训练  | 正常训练  |  |  |
 | BiSeNetV2 | BiSeNetV2 | 正常训练  | 正常训练  |  |  |
 | OCRNet | OCRNet_HRNetW18 | 正常训练  | 正常训练  |  |  |
+| OCRNet | OCRNet_HRNetW48 | 正常训练  | 正常训练  |  |  |
 | Segformer | Segformer_B0 | 正常训练  | 正常训练  |  |  |
 | STDC | STDC_STDC1 | 正常训练  | 正常训练  |  |  |
 | MODNet | PP-Matting | 正常训练  | 正常训练  |  |  |
 | PFPNNet | PFPNNet | 正常训练 | 正常训练 |  |  |
 | ENet | ENet | 正常训练 | 正常训练 |  |  |
+| FastSCNN | FastSCNN | 正常训练 | 正常训练 |  |  |
 
 
 - 预测相关：基于训练是否使用量化，可以将训练产出的模型可以分为`正常模型`和`量化模型`，这两类模型对应的预测功能汇总如下，

--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -64,18 +64,18 @@ else
         rm -rf ./test_tipc/data/mini_supervisely
         wget -nc -P ./test_tipc/data/ https://paddleseg.bj.bcebos.com/humanseg/data/mini_supervisely.zip
         cd ./test_tipc/data/ && unzip mini_supervisely.zip && cd -
-    elif [ ${model_name} == "ocrnet_hrnetw18" ] || [ ${model_name} == "bisenetv2" ] || [ ${model_name} == "segformer_b0" ] || [ ${model_name} == "stdc_stdc1" ] || [ ${model_name} == "pfpnnet" ] || [ ${model_name} == "enet" ];then
-        rm -rf ./test_tipc/data/cityscapes
-        wget -nc -P ./test_tipc/data/ https://paddleseg.bj.bcebos.com/dataset/cityscapes.tar
-        cd ./test_tipc/data/ && tar -xvf cityscapes.tar && cd -
     elif [ ${model_name} == "ppmatting" ];then
         rm -rf ./test_tipc/data/PPM-100
         wget -nc -P ./test_tipc/data/ https://paddleseg.bj.bcebos.com/matting/datasets/PPM-100.zip
         cd ./test_tipc/data/ && unzip PPM-100.zip && cd -
-
+    else
+        rm -rf ./test_tipc/data/cityscapes
+        wget -nc -P ./test_tipc/data/ https://paddleseg.bj.bcebos.com/dataset/cityscapes.tar
+        cd ./test_tipc/data/ && tar -xf cityscapes.tar && cd -
     fi
 fi
 
-if [ ${model_name} == "enet" ] || [ ${model_name} == "bisenetv2" ] || [ ${model_name} == "ocrnet_hrnetw18" ];then
+if [ ${model_name} == "enet" ] || [ ${model_name} == "bisenetv2" ] || [ ${model_name} == "ocrnet_hrnetw18" ] || [ ${model_name} == "ocrnet_hrnetw48" ] \
+    || [ ${model_name} == "deeplabv3p_resnet50_cityscapes" ]|| [ ${model_name} == "fastscnn" ]|| [ ${model_name} == "fcn_hrnetw18" ];then
     cp ./test_tipc/data/cityscapes_val_5.list ./test_tipc/data/cityscapes
 fi

--- a/test_tipc/requirements.txt
+++ b/test_tipc/requirements.txt
@@ -10,3 +10,4 @@ scipy
 prettytable
 paddleseg
 scikit-image
+numba


### PR DESCRIPTION
1 TIPC基础链条新增4个模型：fastscnn, hrnetw18, ocrnet_hrnetw48, deeplabv3p_resnet50_cityscapes
2 修复PPMatting目录调整导致的问题和依赖问题
3 修复ENet Python版本问题