### PR TITLE
[Matting] Add `fg_estimate` parameter for prediction

### DIFF
--- a/Matting/README.md
+++ b/Matting/README.md
@@ -194,9 +194,12 @@ python predict.py \
     --config configs/modnet/modnet-mobilenetv2.yml \
     --model_path output/best_model/model.pdparams \
     --image_path data/PPM-100/val/fg/ \
-    --save_dir ./output/results
+    --save_dir ./output/results \
+    --fg_estimate True
 ```
 If the model requires trimap information, pass the trimap path through '--trimap_path'.
+
+`--fg_Estimate False` can turn off foreground estimation, which improves prediction speed but reduces image quality.
 
 You can directly download the provided model for evaluation.
 
@@ -213,11 +216,14 @@ python bg_replace.py \
     --model_path output/best_model/model.pdparams \
     --image_path path/to/your/image \
     --background path/to/your/background/image \
-    --save_dir ./output/results
+    --save_dir ./output/results \
+    --fg_estimate True
 ```
 If the model requires trimap information, pass the trimap path through `--trimap_path`.
 
 `--background` can pass a path of brackground image or select one of ('r', 'g', 'b', 'w') which represent red, green, blue and white. If it is not specified, a green background is used.
+
+`--fg_Estimate False` can turn off foreground estimation, which improves prediction speed but reduces image quality.
 
 **note：** `--image_path` must be a image path。
 
@@ -248,9 +254,12 @@ python export.py --help
 python deploy/python/infer.py \
     --config output/export/deploy.yaml \
     --image_path data/PPM-100/val/fg/ \
-    --save_dir output/results
+    --save_dir output/results \
+    --fg_estimate True
 ```
 If the model requires trimap information, pass the trimap path through '--trimap_path'.
+
+`--fg_Estimate False` can turn off foreground estimation, which improves prediction speed but reduces image quality.
 
 Run the following command to view more parameters.
 ```shell

--- a/Matting/README_CN.md
+++ b/Matting/README_CN.md
@@ -196,9 +196,11 @@ python predict.py \
     --config configs/modnet/modnet-mobilenetv2.yml \
     --model_path output/best_model/model.pdparams \
     --image_path data/PPM-100/val/fg/ \
-    --save_dir ./output/results
+    --save_dir ./output/results \
+    --fg_estimate True
 ```
 如模型需要trimap信息，需要通过`--trimap_path`传入trimap路径。
+`--fg_estimate False` 可关闭前景估计功能，可提升预测速度，但图像质量会有所降低
 
 你可以直接下载我们提供的模型进行预测。
 
@@ -216,11 +218,13 @@ python bg_replace.py \
     --model_path output/best_model/model.pdparams \
     --image_path path/to/your/image \
     --background path/to/your/background/image \
-    --save_dir ./output/results
+    --save_dir ./output/results \
+    --fg_estimate True
 ```
 如模型需要trimap信息，需要通过`--trimap_path`传入trimap路径。
 
 `--background`可以传入背景图片路劲，或选择（'r','g','b','w')中的一种，代表红，绿，蓝，白背景, 若不提供则采用绿色作为背景。
+`--fg_estimate False` 可关闭前景估计功能，可提升预测速度，但图像质量会有所降低
 
 **注意：** `--image_path`必须是一张图片的具体路径。
 
@@ -251,9 +255,11 @@ python export.py --help
 python deploy/python/infer.py \
     --config output/export/deploy.yaml \
     --image_path data/PPM-100/val/fg/ \
-    --save_dir output/results
+    --save_dir output/results \
+    --fg_estimate True
 ```
 如模型需要trimap信息，需要通过`--trimap_path`传入trimap路径。
+`--fg_estimate False` 可关闭前景估计功能，可提升预测速度，但图像质量会有所降低
 
 更多参数信息请运行如下命令进行查看:
 ```shell

--- a/Matting/README_CN.md
+++ b/Matting/README_CN.md
@@ -200,6 +200,7 @@ python predict.py \
     --fg_estimate True
 ```
 如模型需要trimap信息，需要通过`--trimap_path`传入trimap路径。
+
 `--fg_estimate False` 可关闭前景估计功能，可提升预测速度，但图像质量会有所降低
 
 你可以直接下载我们提供的模型进行预测。
@@ -224,6 +225,7 @@ python bg_replace.py \
 如模型需要trimap信息，需要通过`--trimap_path`传入trimap路径。
 
 `--background`可以传入背景图片路劲，或选择（'r','g','b','w')中的一种，代表红，绿，蓝，白背景, 若不提供则采用绿色作为背景。
+
 `--fg_estimate False` 可关闭前景估计功能，可提升预测速度，但图像质量会有所降低
 
 **注意：** `--image_path`必须是一张图片的具体路径。
@@ -259,6 +261,7 @@ python deploy/python/infer.py \
     --fg_estimate True
 ```
 如模型需要trimap信息，需要通过`--trimap_path`传入trimap路径。
+
 `--fg_estimate False` 可关闭前景估计功能，可提升预测速度，但图像质量会有所降低
 
 更多参数信息请运行如下命令进行查看:

--- a/Matting/deploy/python/infer.py
+++ b/Matting/deploy/python/infer.py
@@ -73,6 +73,12 @@ def parse_args():
         choices=['cpu', 'gpu'],
         default="gpu",
         help="Select which device to inference, defaults to gpu.")
+    parser.add_argument(
+        '--fg_estimate',
+        default=True,
+        type=eval,
+        choices=[True, False],
+        help='Whether to estimate foreground when predicting.')
 
     parser.add_argument(
         '--cpu_threads',
@@ -452,7 +458,10 @@ class Predictor:
 
         # save clip image
         mkdir(clip_save_path)
-        fg = estimate_foreground_ml(ori_img / 255.0, alpha / 255.0) * 255
+        if args.fg_estimate:
+            fg = estimate_foreground_ml(ori_img / 255.0, alpha / 255.0) * 255
+        else:
+            fg = ori_img
         fg = fg.astype('uint8')
         alpha = alpha[:, :, np.newaxis]
         clip = np.concatenate([fg, alpha], axis=-1)

--- a/Matting/predict.py
+++ b/Matting/predict.py
@@ -55,6 +55,12 @@ def parse_args():
         help='The directory for saving the model snapshot',
         type=str,
         default='./output/results')
+    parser.add_argument(
+        '--fg_estimate',
+        default=True,
+        type=eval,
+        choices=[True, False],
+        help='Whether to estimate foreground when predicting.')
 
     return parser.parse_args()
 
@@ -92,7 +98,8 @@ def main(args):
         image_list=image_list,
         image_dir=image_dir,
         trimap_list=trimap_list,
-        save_dir=args.save_dir)
+        save_dir=args.save_dir,
+        fg_estimate=args.fg_estimate)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add `fg_estimate` parameter for prediction to determine whether to turn on or off foreground estimation while prediction. 