### PR TITLE
[Improvement] Support all_reduce under eager mode

### DIFF
--- a/paddleseg/models/emanet.py
+++ b/paddleseg/models/emanet.py
@@ -19,6 +19,7 @@ import paddle.nn.functional as F
 from paddleseg.models import layers
 from paddleseg.cvlibs import manager
 from paddleseg.utils import utils
+from paddle.fluid.framework import in_dygraph_mode, _in_legacy_dygraph
 
 
 @manager.MODELS.add_component
@@ -209,7 +210,10 @@ class EMAU(nn.Layer):
             mu = F.normalize(mu, axis=1, p=2)
             mu = self.mu * (1 - self.momentum) + mu * self.momentum
             if paddle.distributed.get_world_size() > 1:
-                mu = paddle.distributed.all_reduce(mu)
+                if in_dygraph_mode():
+                    paddle.distributed.all_reduce(mu)
+                elif _in_legacy_dygraph():
+                    mu = paddle.distributed.all_reduce(mu)
                 mu /= paddle.distributed.get_world_size()
             self.mu = mu
 


### PR DESCRIPTION
paddle.distributed.all_reduce(input) 接口 在新老动态图行为不完全一致。
在新动态图中，all_reduce 的结果直接 inplaced 改写进输入，
在老动态图中，all_reduce 的结果作为返回值，返回一个新的 tensor。