### PR TITLE
[Fix] Add windows case

### DIFF
--- a/paddleseg/utils/env/sys_env.py
+++ b/paddleseg/utils/env/sys_env.py
@@ -58,8 +58,12 @@ def _get_nvcc_info(cuda_home):
     if cuda_home is not None and os.path.isdir(cuda_home):
         try:
             nvcc = os.path.join(cuda_home, 'bin/nvcc')
-            nvcc = subprocess.check_output(
-                "{} -V".format(nvcc), shell=True).decode()
+            if not IS_WINDOWS:
+                nvcc = subprocess.check_output(
+                    "{} -V".format(nvcc), shell=True).decode()
+            else:
+                nvcc = subprocess.check_output(
+                    "\"{}\" -V".format(nvcc), shell=True).decode()
             nvcc = nvcc.strip().split('\n')[-1]
         except subprocess.SubprocessError:
             nvcc = "Not Available"


### PR DESCRIPTION
same as issue https://github.com/PaddlePaddle/PaddleSeg/pull/2279


----------------------
My `cuda_home` is `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6`, which has some space.
So after 
```
nvcc = subprocess.check_output(
                "{} -V".format(nvcc), shell=True).decode()
```
it will be `'C:\Program' 不是内部或外部命令，也不是可运行的程序或批处理文件。` 
whose reason is the windows cmd can't deal with the space correctly.

So we should put double quotes around `C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.6\bin/nvcc`, 
which is why  `"\"{}\" -V"` is needed.