### PR TITLE
[Fix] Add ignore_index parameter in L1 loss in release/2.6

### DIFF
--- a/paddleseg/models/losses/l1_loss.py
+++ b/paddleseg/models/losses/l1_loss.py
@@ -41,7 +41,6 @@ class L1Loss(nn.L1Loss):
             If `reduction` is ``'mean'``, the reduced mean loss is returned.
             If `reduction` is ``'sum'``, the reduced sum loss is returned.
             Default is ``'mean'``.
-        ignore_index (int, optional): Specifies a target value that is ignored and does not contribute to the input gradient. Default: 255.
     Shape:
         input (Tensor): The input tensor. The shapes is [N, *], where N is batch size and `*` means any number of additional dimensions. It's data type should be float32, float64, int32, int64.
         label (Tensor): label. The shapes is [N, *], same shape as ``input`` . It's data type should be float32, float64, int32, int64.
@@ -72,5 +71,5 @@ class L1Loss(nn.L1Loss):
             # [0.2        0.79999995]]
     """
 
-    def __init__(self, reduction='mean', ignore_index=255):
+    def __init__(self, reduction='mean'):
         super().__init__(reduction=reduction)

--- a/paddleseg/models/losses/l1_loss.py
+++ b/paddleseg/models/losses/l1_loss.py
@@ -77,6 +77,7 @@ class L1Loss(nn.L1Loss):
     
     def forward(self, input, label):
         mask = label==self.ignore_index
+        mask.stop_gradient = True
         label[mask] = 0
         input[mask] = 0
         

--- a/paddleseg/models/losses/l1_loss.py
+++ b/paddleseg/models/losses/l1_loss.py
@@ -41,6 +41,7 @@ class L1Loss(nn.L1Loss):
             If `reduction` is ``'mean'``, the reduced mean loss is returned.
             If `reduction` is ``'sum'``, the reduced sum loss is returned.
             Default is ``'mean'``.
+        ignore_index (int, optional): Specifies a target value that is ignored and does not contribute to the input gradient. Default: 255.
     Shape:
         input (Tensor): The input tensor. The shapes is [N, *], where N is batch size and `*` means any number of additional dimensions. It's data type should be float32, float64, int32, int64.
         label (Tensor): label. The shapes is [N, *], same shape as ``input`` . It's data type should be float32, float64, int32, int64.

--- a/paddleseg/models/losses/l1_loss.py
+++ b/paddleseg/models/losses/l1_loss.py
@@ -71,5 +71,15 @@ class L1Loss(nn.L1Loss):
             # [0.2        0.79999995]]
     """
 
-    def __init__(self, reduction='mean'):
+    def __init__(self, reduction='mean', ignore_index=255):
         super().__init__(reduction=reduction)
+        self.ignore_index = ignore_index
+    
+    def forward(self, input, label):
+        mask = label==self.ignore_index
+        label[mask] = 0
+        input[mask] = 0
+        
+        return paddle.nn.functional.l1_loss(
+            input, label, self.reduction, name=self.name)
+ 


### PR DESCRIPTION
fix issue https://github.com/PaddlePaddle/PaddleSeg/issues/2354
验证有无ignoreindex在三种reduction下均得到相同结果，且mean方式下，backward正常传播。

<img width="798" alt="image" src="https://user-images.githubusercontent.com/34859558/186147596-44b901d0-3763-4c00-839a-998e3a9dd661.png">
<img width="797" alt="image" src="https://user-images.githubusercontent.com/34859558/186147683-6f313db2-4e6c-46ec-b37f-87dda7299260.png">
<img width="795" alt="image" src="https://user-images.githubusercontent.com/34859558/186147839-a25ea968-db80-47ae-993e-dd9d069bb8de.png">


