### PR TITLE
Fix PPLiteSeg Dygraph to Static

### DIFF
--- a/paddleseg/models/layers/tensor_fusion.py
+++ b/paddleseg/models/layers/tensor_fusion.py
@@ -176,6 +176,7 @@ class UAFM_SpAtten(UAFM):
             shape=[1],
             attr=ParamAttr(initializer=Constant(value=1.)),
             dtype="float32")
+        self._scale.stop_gradient = True
 
     def fuse(self, x, y):
         """


### PR DESCRIPTION
forward中直接使用 1-x 会导致动转静后 产生多出来的scale：
<img width="404" alt="屏幕快照 2022-08-02 下午4 45 48" src="https://user-images.githubusercontent.com/28942475/182332907-e2b4ba72-be48-4cca-a12a-686c7efd7f3b.png">
init中提前定义此参数即可：
<img width="492" alt="屏幕快照 2022-08-02 下午4 45 17" src="https://user-images.githubusercontent.com/28942475/182333013-d7516d51-c319-4250-8711-fb49835a1b7b.png">
