### PR TITLE
[MedicalSeg] Fix MedicalSeg TIPC bugs

### DIFF
--- a/contrib/MedicalSeg/test_tipc/common_func.sh
+++ b/contrib/MedicalSeg/test_tipc/common_func.sh
@@ -16,22 +16,6 @@ function func_parser_value(){
     echo ${tmp}
 }
 
-function func_parser_key_cpp(){
-    strs=$1
-    IFS=" "
-    array=(${strs})
-    tmp=${array[0]}
-    echo ${tmp}
-}
-
-function func_parser_value_cpp(){
-    strs=$1
-    IFS=" "
-    array=(${strs})
-    tmp=${array[1]}
-    echo ${tmp}
-}
-
 function func_set_params(){
     key=$1
     value=$2
@@ -78,19 +62,6 @@ function status_check(){
     else
         echo -e "\033[33m Run failed with command - ${model_name} - ${run_command}!  \033[0m" | tee -a ${run_log}
     fi
-}
-
-function contains() {
-    local n=$#
-    local value=${!n}
-    for ((i=1;i < $#;i++)) {
-        if [ "${!i}" == "${value}" ]; then
-            echo "y"
-            return 0
-        fi
-    }
-    echo "n"
-    return 1
 }
 
 function run_command() {

--- a/contrib/MedicalSeg/test_tipc/common_func.sh
+++ b/contrib/MedicalSeg/test_tipc/common_func.sh
@@ -16,6 +16,22 @@ function func_parser_value(){
     echo ${tmp}
 }
 
+function func_parser_key_cpp(){
+    strs=$1
+    IFS=" "
+    array=(${strs})
+    tmp=${array[0]}
+    echo ${tmp}
+}
+
+function func_parser_value_cpp(){
+    strs=$1
+    IFS=" "
+    array=(${strs})
+    tmp=${array[1]}
+    echo ${tmp}
+}
+
 function func_set_params(){
     key=$1
     value=$2
@@ -53,12 +69,37 @@ function func_parser_params(){
 }
 
 function status_check(){
-    last_status=$1   # the exit code
-    run_command=$2
-    run_log=$3
+    local last_status=$1   # the exit code
+    local run_command=$2
+    local run_log=$3
+    local model_name=$4
     if [ $last_status -eq 0 ]; then
-        echo -e "\033[33m Run successfully with command - ${run_command}!  \033[0m" | tee -a ${run_log}
+        echo -e "\033[33m Run successfully with command - ${model_name} - ${run_command}!  \033[0m" | tee -a ${run_log}
     else
-        echo -e "\033[33m Run failed with command - ${run_command}!  \033[0m" | tee -a ${run_log}
+        echo -e "\033[33m Run failed with command - ${model_name} - ${run_command}!  \033[0m" | tee -a ${run_log}
+    fi
+}
+
+function contains() {
+    local n=$#
+    local value=${!n}
+    for ((i=1;i < $#;i++)) {
+        if [ "${!i}" == "${value}" ]; then
+            echo "y"
+            return 0
+        fi
+    }
+    echo "n"
+    return 1
+}
+
+function run_command() {
+    local cmd="$1"
+    local log_path="$2"
+    if [ -n "${log_path}" ]; then
+        eval ${cmd} | tee "${log_path}"
+        test ${PIPESTATUS[0]} -eq 0
+    else
+        eval ${cmd}
     fi
 }

--- a/contrib/MedicalSeg/test_tipc/configs/unetr/train_infer_python.txt
+++ b/contrib/MedicalSeg/test_tipc/configs/unetr/train_infer_python.txt
@@ -5,7 +5,7 @@ gpu_list:0
 Global.use_gpu:null|null
 --precision:fp32
 --iters:lite_train_lite_infer=20|whole_train_whole_infer=500
---save_dir:./test_tipc//result/unetr/
+--save_dir:./test_tipc/result/unetr/
 --batch_size:lite_train_lite_infer=2|whole_train_whole_infer=4
 --model_path:null
 train_model_name:latest

--- a/contrib/MedicalSeg/test_tipc/configs/unetr/train_infer_python.txt
+++ b/contrib/MedicalSeg/test_tipc/configs/unetr/train_infer_python.txt
@@ -2,18 +2,18 @@
 model_name:UNETR
 python:python3
 gpu_list:0
-Global.use_gpu:True|True
-Global.auto_cast:fp32
-Global.epoch_num:lite_train_lite_infer=1|whole_train_whole_infer=500
-Global.save_model_dir:./test_tipc//result/unetr/
-Train.loader.batch_size_per_card:lite_train_lite_infer=2|whole_train_whole_infer=4
-Global.pretrained_model:null
+Global.use_gpu:null|null
+--precision:fp32
+--iters:lite_train_lite_infer=20|whole_train_whole_infer=500
+--save_dir:./test_tipc//result/unetr/
+--batch_size:lite_train_lite_infer=2|whole_train_whole_infer=4
+--model_path:null
 train_model_name:latest
-train_infer_img_dir:./test_tipc/data/mini_brainT_dataset
+train_infer_img_dir:./test_tipc/data/mini_brainT_dataset/images
 null:null
 ##
 trainer:norm_train
-norm_train:./train.py --config test_tipc/configs/unetr/msd_brain_test.yml --save_dir saved_model1/ --save_interval 20 --log_iters 5 --num_workers 2 --do_eval --use_vdl --keep_checkpoint_max 1 --seed 0 --sw_num 20 --is_save_data False --has_dataset_json False
+norm_train:./train.py --config test_tipc/configs/unetr/msd_brain_test.yml --save_interval 20 --log_iters 5 --num_workers 2 --do_eval --keep_checkpoint_max 1 --seed 0 --sw_num 20 --is_save_data False --has_dataset_json False
 pact_train:null
 fpgm_train:null
 distill_train:null
@@ -21,22 +21,32 @@ null:null
 null:null
 ##
 ===========================eval_params===========================
-eval:./test.py --config test_tipc/configs/unetr/msd_brain_test.yml --model_path  saved_model1/best_model/model.pdparams --save_dir   saved_model/msd_brain/best_model/ --num_workers 1 --sw_num 20 --is_save_data False --has_dataset_json False
+eval:./test.py --config test_tipc/configs/unetr/msd_brain_test.yml --num_workers 1 --sw_num 20 --is_save_data False --has_dataset_json False
 null:null
 ##
-===========================infer_params===========================
-Global.save_inference_dir:./test_tipc/result/inference_model/
-Global.pretrained_model:
-norm_export:./export.py --config test_tipc/configs/unetr/msd_brain_test.yml --save_dir  staticmodel1/  --model_path  saved_model1/best_model/model.pdparams --without_argmax  --input_shape 1 4 128 128 128
+===========================export_params===========================
+--save_dir:
+--model_path:
+norm_export:./export.py --config test_tipc/configs/unetr/msd_brain_test.yml --without_argmax  --input_shape 1 4 128 128 128
 quant_export:null
 fpgm_export:null
 distill_export:null
 export1:null
 export2:null
-inference_dir:./test_tipc/result/inference_model/
-infer_model:null
-infer_export:null
+===========================infer_params===========================
+infer_model:
+infer_export:./export.py --config test_tipc/configs/unetr/msd_brain_test.yml --without_argmax  --input_shape 1 4 128 128 128
 infer_quant:False
-inference:./deploy/python/infer.py --config staticmodel1/deploy.yaml --image_path test_tipc/data/mini_brainT_dataset/images --benchmark True --batch_size 1 --use_swl True --use_warmup False
-null:null
---enable_benchmark:True
+inference:./deploy/python/infer.py --use_swl True --use_warmup False
+--device:gpu
+--enable_mkldnn:False
+--cpu_threads:1
+--batch_size:1
+--use_trt:False
+--precision:fp32
+--config:
+--image_path:test_tipc/data/mini_brainT_dataset/images
+--save_log_path:null
+--benchmark:True
+--save_dir:
+--model_name:UNETR

--- a/contrib/MedicalSeg/test_tipc/prepare.sh
+++ b/contrib/MedicalSeg/test_tipc/prepare.sh
@@ -13,13 +13,12 @@ IFS=$'\n'
 lines=(${dataline})
 
 # The training params
-model_name=$(func_parser_value "${lines[4]}")
+model_name=$(func_parser_value "${lines[1]}")
 
 trainer_list=$(func_parser_value "${lines[14]}")
 
 # MODE be one of ['lite_train_lite_infer']
 if [ ${MODE} = "lite_train_lite_infer" ];then
-
     mkdir -p ./test_tipc/data
     rm -rf ./test_tipc/data/mini_levir_dataset
     cd ./test_tipc/data/

--- a/contrib/MedicalSeg/test_tipc/test_train_inference_python.sh
+++ b/contrib/MedicalSeg/test_tipc/test_train_inference_python.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
-source ./test_tipc/common_func.sh
+source test_tipc/common_func.sh
 
 FILENAME=$1
 # MODE be one of ['lite_train_lite_infer' 'lite_train_whole_infer' 'whole_train_whole_infer', 'whole_infer', 'klquant_whole_infer']
 MODE=$2
 
-dataline=$(awk 'NR==1, NR==51{print}'  $FILENAME)
+dataline=$(awk 'NR>=1{print}'  $FILENAME)
 
 # parser params
 IFS=$'\n'
@@ -14,21 +14,20 @@ lines=(${dataline})
 # The training params
 model_name=$(func_parser_value "${lines[1]}")
 python=$(func_parser_value "${lines[2]}")
-python="python"
 gpu_list=$(func_parser_value "${lines[3]}")
 train_use_gpu_key=$(func_parser_key "${lines[4]}")
 train_use_gpu_value=$(func_parser_value "${lines[4]}")
 autocast_list=$(func_parser_value "${lines[5]}")
 autocast_key=$(func_parser_key "${lines[5]}")
 epoch_key=$(func_parser_key "${lines[6]}")
-epoch_num=$(func_parser_value "${lines[6]}")
+epoch_num=$(func_parser_params "${lines[6]}")
 save_model_key=$(func_parser_key "${lines[7]}")
 train_batch_key=$(func_parser_key "${lines[8]}")
-train_batch_value=$(func_parser_value "${lines[8]}")
+train_batch_value=$(func_parser_params "${lines[8]}")
 pretrain_model_key=$(func_parser_key "${lines[9]}")
 pretrain_model_value=$(func_parser_value "${lines[9]}")
 train_model_name=$(func_parser_value "${lines[10]}")
-train_infer_video_dir=$(func_parser_value "${lines[11]}")
+train_infer_img_dir=$(func_parser_value "${lines[11]}")
 train_param_key1=$(func_parser_key "${lines[12]}")
 train_param_value1=$(func_parser_value "${lines[12]}")
 
@@ -51,8 +50,6 @@ eval_key1=$(func_parser_key "${lines[24]}")
 eval_value1=$(func_parser_value "${lines[24]}")
 
 save_infer_key=$(func_parser_key "${lines[27]}")
-save_infer_value=$(func_parser_value "${lines[27]}")
-
 export_weight=$(func_parser_key "${lines[28]}")
 norm_export=$(func_parser_value "${lines[29]}")
 pact_export=$(func_parser_value "${lines[30]}")
@@ -83,16 +80,15 @@ use_trt_list=$(func_parser_value "${lines[44]}")
 precision_key=$(func_parser_key "${lines[45]}")
 precision_list=$(func_parser_value "${lines[45]}")
 infer_model_key=$(func_parser_key "${lines[46]}")
-infer_model_value=$(func_parser_value "${lines[46]}")
-
-video_dir_key=$(func_parser_key "${lines[47]}")
-infer_video_dir=$(func_parser_value "${lines[47]}")
+image_dir_key=$(func_parser_key "${lines[47]}")
+infer_img_dir=$(func_parser_value "${lines[47]}")
 save_log_key=$(func_parser_key "${lines[48]}")
 benchmark_key=$(func_parser_key "${lines[49]}")
 benchmark_value=$(func_parser_value "${lines[49]}")
-
 infer_key1=$(func_parser_key "${lines[50]}")
 infer_value1=$(func_parser_value "${lines[50]}")
+infer_key2=$(func_parser_key "${lines[51]}")	##
+infer_value2=$(func_parser_value "${lines[51]}") ##
 
 # parser klquant_infer
 if [ ${MODE} = "klquant_whole_infer" ]; then
@@ -119,8 +115,8 @@ if [ ${MODE} = "klquant_whole_infer" ]; then
     precision_key=$(func_parser_key "${lines[12]}")
     precision_list=$(func_parser_value "${lines[12]}")
     infer_model_key=$(func_parser_key "${lines[13]}")
-    video_dir_key=$(func_parser_key "${lines[14]}")
-    infer_video_dir=$(func_parser_value "${lines[14]}")
+    image_dir_key=$(func_parser_key "${lines[14]}")
+    infer_img_dir=$(func_parser_value "${lines[14]}")
     save_log_key=$(func_parser_key "${lines[15]}")
     benchmark_key=$(func_parser_key "${lines[16]}")
     benchmark_value=$(func_parser_value "${lines[16]}")
@@ -128,18 +124,26 @@ if [ ${MODE} = "klquant_whole_infer" ]; then
     infer_value1=$(func_parser_value "${lines[17]}")
 fi
 
-LOG_PATH="./test_tipc/output/${model_name}"
+LOG_PATH="./test_tipc/output/${model_name}/${MODE}"  ##
 mkdir -p ${LOG_PATH}
 status_log="${LOG_PATH}/results_python.log"
+echo "------------------------ ${MODE} ------------------------" >> $status_log
 
+
+if [ "${MODE}" = 'benchmark_train' ];then
+    if [ "${autocast_key}" = 'Global.auto_cast' ];then
+        echo 'Replcace ${autocast_key}'"('${autocast_key}') with '--precision'"
+        autocast_key="--precision"
+    fi
+fi
 
 function func_inference(){
     IFS='|'
     _python=$1
     _script=$2
-    _model_dir=$3
+    _model_dir="$3/deploy.yaml"
     _log_path=$4
-    _video_dir=$5
+    _img_dir=$5
     _flag_quant=$6
     # inference
     for use_gpu in ${use_gpu_list[*]}; do
@@ -157,20 +161,27 @@ function func_inference(){
                             if [ ${_flag_quant} = "True" ] && [ ${precision} != "int8" ]; then
                                 continue
                             fi # skip when quant model inference but precision is not int8
+                            if [ ${_flag_quant} = "False" ] && [ ${precision} != "fp32" ]; then ##
+                                continue
+                            fi # skip when not quant model inference and precision is not fp32
+
                             set_precision=$(func_set_params "${precision_key}" "${precision}")
 
                             _save_log_path="${_log_path}/python_infer_cpu_usemkldnn_${use_mkldnn}_threads_${threads}_precision_${precision}_batchsize_${batch_size}.log"
-                            set_infer_data=$(func_set_params "${video_dir_key}" "${infer_video_dir}")
+                            infer_value1="${_log_path}/python_infer_cpu_usemkldnn_${use_mkldnn}_threads_${threads}_precision_${precision}_batchsize_${batch_size}_results"
+                            set_infer_data=$(func_set_params "${image_dir_key}" "${_img_dir}")
                             set_benchmark=$(func_set_params "${benchmark_key}" "${benchmark_value}")
                             set_batchsize=$(func_set_params "${batch_size_key}" "${batch_size}")
                             set_cpu_threads=$(func_set_params "${cpu_threads_key}" "${threads}")
-                            set_model_dir=$(func_set_params "${infer_model_key}" "${infer_model_value}")
-                            set_infer_params1=$(func_set_params "${infer_key1}" "${infer_value1}")
-                            command="${_python} ${_script} ${use_gpu_key}=${use_gpu} ${use_mkldnn_key}=${use_mkldnn} ${set_cpu_threads} ${set_model_dir} ${set_batchsize} ${set_infer_data} ${set_benchmark} ${set_precision} ${set_infer_params1} > ${_save_log_path} 2>&1 "
+                            set_model_dir=$(func_set_params "${infer_model_key}" "${_model_dir}")
+                            set_infer_params1=$(func_set_params "${infer_key1}" "${infer_value1}")  ##
+                            set_infer_params2=$(func_set_params "${infer_key2}" "${infer_value2}")  ##
+                            command="${_python} ${_script} ${use_gpu_key}=${use_gpu} ${use_mkldnn_key}=${use_mkldnn} ${set_cpu_threads} ${set_model_dir} ${set_batchsize} ${set_infer_data} ${set_benchmark} ${set_precision} ${set_infer_params1} ${set_infer_params2} > ${_save_log_path} 2>&1 " ##
+                            echo $command
                             eval $command
                             last_status=${PIPESTATUS[0]}
                             eval "cat ${_save_log_path}"
-                            status_check $last_status "${command}" "${status_log}"
+                            status_check $last_status "${command}" "${status_log}" "${model_name}"
                         done
                     done
                 done
@@ -189,19 +200,21 @@ function func_inference(){
                     fi
                     for batch_size in ${batch_size_list[*]}; do
                         _save_log_path="${_log_path}/python_infer_gpu_usetrt_${use_trt}_precision_${precision}_batchsize_${batch_size}.log"
-                        set_infer_data=$(func_set_params "${video_dir_key}" "${infer_video_dir}")
+                        infer_value1="${_log_path}/python_infer_gpu_usetrt_${use_trt}_precision_${precision}_batchsize_${batch_size}_results"
+                        set_infer_data=$(func_set_params "${image_dir_key}" "${_img_dir}")
+                        set_benchmark=$(func_set_params "${benchmark_key}" "${benchmark_value}")
                         set_batchsize=$(func_set_params "${batch_size_key}" "${batch_size}")
                         set_tensorrt=$(func_set_params "${use_trt_key}" "${use_trt}")
                         set_precision=$(func_set_params "${precision_key}" "${precision}")
-                        set_model_dir=$(func_set_params "${infer_model_key}" "${infer_model_value}")
-                        set_infer_params1=$(func_set_params "${infer_key1}" "${infer_value1}")
-                        command="${_python} ${_script} ${use_gpu_key}=${use_gpu} ${set_tensorrt} ${set_precision} ${set_model_dir} ${set_batchsize} ${set_infer_data} ${set_benchmark} ${set_infer_params1} > ${_save_log_path} 2>&1 "
-
+                        set_model_dir=$(func_set_params "${infer_model_key}" "${_model_dir}")
+                        set_infer_params1=$(func_set_params "${infer_key1}" "${infer_value1}")  ##
+                        set_infer_params2=$(func_set_params "${infer_key2}" "${infer_value2}")  ##
+                        command="${_python} ${_script} ${use_gpu_key}=${use_gpu} ${set_tensorrt} ${set_precision} ${set_model_dir} ${set_batchsize} ${set_infer_data} ${set_benchmark} ${set_infer_params2} > ${_save_log_path} 2>&1 " ##
+                        echo $command
                         eval $command
-
                         last_status=${PIPESTATUS[0]}
                         eval "cat ${_save_log_path}"
-                        status_check $last_status "${command}" "${status_log}"
+                        status_check $last_status "${command}" "${status_log}" "${model_name}"
 
                     done
                 done
@@ -219,7 +232,7 @@ if [ ${MODE} = "whole_infer" ] || [ ${MODE} = "klquant_whole_infer" ]; then
     else
         env="export CUDA_VISIBLE_DEVICES=${GPUID}"
     fi
-    set CUDA_VISIBLE_DEVICES
+    # set CUDA_VISIBLE_DEVICES
     eval $env
     export Count=0
     IFS="|"
@@ -234,9 +247,8 @@ if [ ${MODE} = "whole_infer" ] || [ ${MODE} = "klquant_whole_infer" ]; then
             export_cmd="${python} ${infer_run_exports[Count]} ${set_export_weight} ${set_save_infer_key}"
             echo ${infer_run_exports[Count]}
             eval $export_cmd
-            echo $export_cmd
             status_export=$?
-            status_check $status_export "${export_cmd}" "${status_log}"
+            status_check $status_export "${export_cmd}" "${status_log}" "${model_name}"
         else
             save_infer_dir=${infer_model}
         fi
@@ -245,7 +257,7 @@ if [ ${MODE} = "whole_infer" ] || [ ${MODE} = "klquant_whole_infer" ]; then
         if [ ${MODE} = "klquant_infer" ]; then
             is_quant="True"
         fi
-        func_inference "${python}" "${inference_py}" "${save_infer_dir}" "${LOG_PATH}" "${infer_video_dir}" ${is_quant}
+        func_inference "${python}" "${inference_py}" "${save_infer_dir}" "${LOG_PATH}" "${infer_img_dir}" ${is_quant}
         Count=$(($Count + 1))
     done
 else
@@ -277,6 +289,8 @@ else
         for autocast in ${autocast_list[*]}; do
             if [ ${autocast} = "amp" ]; then
                 set_amp_config="Global.use_amp=True Global.scale_loss=1024.0 Global.use_dynamic_loss_scaling=True"
+            elif [ "${autocast}" = 'fp16' ] && [ "${MODE}" = 'benchmark_train' ];then
+                set_amp_config="--amp_level=O2"
             else
                 set_amp_config=" "
             fi
@@ -308,20 +322,13 @@ else
                 fi
                 set_autocast=$(func_set_params "${autocast_key}" "${autocast}")
                 set_epoch=$(func_set_params "${epoch_key}" "${epoch_num}")
-
-                if [[ $MODE =~ "whole_train" ]]; then
-                    set_epoch=""
-                fi
-
                 set_pretrain=$(func_set_params "${pretrain_model_key}" "${pretrain_model_value}")
                 set_batchsize=$(func_set_params "${train_batch_key}" "${train_batch_value}")
-                if [[ $MODE =~ "whole_train" ]]; then
-                    train_param_key1=""
-                    train_param_value1=""
-                fi
                 set_train_params1=$(func_set_params "${train_param_key1}" "${train_param_value1}")
                 set_use_gpu=$(func_set_params "${train_use_gpu_key}" "${train_use_gpu}")
-                if [ ${#ips} -le 26 ];then
+                # if length of ips >= 15, then it is seen as multi-machine
+                # 15 is the min length of ips info for multi-machine: 0.0.0.0,0.0.0.0
+                if [ ${#ips} -le 15 ];then
                     save_log="${LOG_PATH}/${trainer}_gpus_${gpu}_autocast_${autocast}"
                     nodes=1
                 else
@@ -331,61 +338,97 @@ else
                     nodes=${#ips_array[@]}
                     save_log="${LOG_PATH}/${trainer}_gpus_${gpu}_autocast_${autocast}_nodes_${nodes}"
                 fi
+                log_path="${LOG_PATH}/${trainer}_gpus_${gpu}_autocast_${autocast}_nodes_${nodes}.log"
 
                 # load pretrain from norm training if current trainer is pact or fpgm trainer
                 if ([ ${trainer} = ${pact_key} ] || [ ${trainer} = ${fpgm_key} ]) && [ ${nodes} -le 1 ]; then
                     set_pretrain="${load_norm_train_model}"
                 fi
 
+                if [ -n "${set_autocast}" ]; then
+                    echo -e "\033[33m Currently, MedicalSeg does not support ${set_autocast} . \033[0m"
+                    set_autocast=""
+                fi
+
                 set_save_model=$(func_set_params "${save_model_key}" "${save_log}")
                 if [ ${#gpu} -le 2 ];then  # train with cpu or single gpu
-                    cmd="${python} ${run_train}"
-                elif [ ${#ips} -le 26 ];then  # train with multi-gpu
-                    cmd="${python} -B -m paddle.distributed.launch --gpus=\"${gpu}\" ${run_train} ${set_use_gpu} ${set_save_model} ${set_epoch} ${set_pretrain} ${set_autocast} ${set_batchsize} ${set_train_params1} ${set_amp_config}"
+                    cmd="${python} ${run_train} ${set_use_gpu}  ${set_save_model} ${set_epoch} ${set_pretrain} ${set_autocast} ${set_batchsize} ${set_train_params1} ${set_amp_config}"
+                elif [ ${#ips} -le 15 ];then  # train with multi-gpu
+                    cmd="${python} -m paddle.distributed.launch --gpus=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_epoch} ${set_pretrain} ${set_autocast} ${set_batchsize} ${set_train_params1} ${set_amp_config}"
                 else     # train with multi-machine
-                    cmd="${python} -B -m paddle.distributed.launch --ips=${ips} --gpus=\"${gpu}\" ${run_train} ${set_use_gpu} ${set_save_model} ${set_pretrain} ${set_epoch} ${set_autocast} ${set_batchsize} ${set_train_params1} ${set_amp_config}"
+                    cmd="${python} -m paddle.distributed.launch --ips=${ips} --gpus=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_pretrain} ${set_epoch} ${set_autocast} ${set_batchsize} ${set_train_params1} ${set_amp_config}"
+                fi
+                
+                if [ -n "${log_iters}" ];then
+                    cmd="${cmd} --log_iters ${log_iters}"
                 fi
 
-                # run train
-                eval "unset CUDA_VISIBLE_DEVICES"
-                eval $cmd
-                status_check $? "${cmd}" "${status_log}"
+                if [ -n "${amp_level}" ];then
+                    cmd="${cmd} --amp_level ${amp_level}"
+                fi
 
-                # set_eval_pretrain=$(func_set_params "${pretrain_model_key}" "${save_log}/${train_model_name}")
+                if [ -n "${set_cv_threads}" ] && [ "${set_cv_threads}" = "true" ];then
+                    # Take the first word as the training script, which means there should be no blanks in the path of script.
+                    train_script=$(echo "${run_train}" | cut -d ' ' -f1)
+                    # Make a copy
+                    train_script_copy="$(add_suffix ${train_script} '_copy')" 
+                    cp ${train_script} ${train_script_copy}
+                    sed -i '1s/^/import cv2; cv2.setNumThreads(1)\n/' ${train_script_copy}
+                    # Use a global replace!
+                    cmd="${cmd/${train_script}/${train_script_copy}}"
+                fi
+
+                echo "$cmd"
+                # run train
+                run_command "${cmd}" "${log_path}"
+                status_check $? "${cmd}" "${status_log}" "${model_name}"
+
+                if [[ "$cmd" == *'paddle.distributed.launch'* ]]; then
+                    cat log/workerlog.0 >> ${log_path} 
+                fi
+
+                if [ -n "${set_cv_threads}" ] && [ "${set_cv_threads}" = "true" ];then
+                    rm ${train_script_copy}
+                fi
+
+                # modify model dir if no eval
+                if [ ! -f "${save_log}/${train_model_name}" ]; then
+                    train_model_name="best_model/model.pdparams"
+                fi
+                set_eval_pretrain=$(func_set_params "${pretrain_model_key}" "${save_log}/${train_model_name}")
                 # save norm trained models to set pretrain for pact training and fpgm training
-                if [ [${trainer} = ${trainer_norm}] ] && [ [${nodes} -le 1] ]; then
+                if [ ${trainer} = ${trainer_norm} ] && [ ${nodes} -le 1 ]; then
                     load_norm_train_model=${set_eval_pretrain}
                 fi
-                # run test
+                # run eval
                 if [ ${eval_py} != "null" ]; then
+                    log_path="${LOG_PATH}/${trainer}_gpus_${gpu}_autocast_${autocast}_nodes_${nodes}_eval.log"
                     set_eval_params1=$(func_set_params "${eval_key1}" "${eval_value1}")
-                    eval_cmd="${python} ${eval_py}"
-                    eval $eval_cmd
-                    status_check $? "${eval_cmd}" "${status_log}"
+                    eval_cmd="${python} ${eval_py} ${set_eval_pretrain} ${set_use_gpu} ${set_eval_params1}"
+                    run_command "${eval_cmd}" "${log_path}"
+                    status_check $? "${eval_cmd}" "${status_log}" "${model_name}"
                 fi
                 # run export model
                 if [ ${run_export} != "null" ]; then
                     # run export model
+                    log_path="${LOG_PATH}/${trainer}_gpus_${gpu}_autocast_${autocast}_nodes_${nodes}_export.log"
                     save_infer_path="${save_log}"
-                    set_export_weight=$(func_set_params "${export_weight}" "${eval_value1}")
-                    set_save_infer_key=$(func_set_params "${save_infer_key}" "${save_infer_value}")
-                    export_cmd="${python} ${run_export}"
-                    eval $export_cmd
-                    status_check $? "${export_cmd}" "${status_log}"
+                    set_export_weight=$(func_set_params "${export_weight}" "${save_log}/${train_model_name}")
+                    set_save_infer_key=$(func_set_params "${save_infer_key}" "${save_infer_path}")
+                    export_cmd="${python} ${run_export} ${set_export_weight} ${set_save_infer_key}"
+                    run_command "${export_cmd}" "${log_path}"
+                    status_check $? "${export_cmd}" "${status_log}" "${model_name}"
 
                     #run inference
                     eval $env
                     save_infer_path="${save_log}"
-                    if [ ${inference_dir} != "null" ] && [ ${inference_dir} != '##' ]; then
+                    if [[ ${inference_dir} != "null" ]] && [[ ${inference_dir} != '##' ]]; then ##
                         infer_model_dir="${save_infer_path}/${inference_dir}"
                     else
                         infer_model_dir=${save_infer_path}
                     fi
-                    # echo  1111
-                    # func_inference "${python}" "${inference_py}" "${infer_model_dir}" "${LOG_PATH}" "${train_infer_video_dir}" "${flag_quant}"
-                    infer="${python} ${inference_py}"
-                    # echo  $infer
-                    eval $infer
+                    func_inference "${python}" "${inference_py}" "${infer_model_dir}" "${LOG_PATH}" "${train_infer_img_dir}" "${flag_quant}"
+
                     eval "unset CUDA_VISIBLE_DEVICES"
                 fi
             done  # done with:    for trainer in ${trainer_list[*]}; do

--- a/contrib/MedicalSeg/tools/prepare.py
+++ b/contrib/MedicalSeg/tools/prepare.py
@@ -139,7 +139,10 @@ class Prep:
         """unzip all the file in the root directory"""
         files = glob.glob(os.path.join(self.dataset_root, "*.{}".format(form)))
 
-        assert len(files) == num_files, "The file directory should include {} compressed files, but there is only {}".format(num_files, len(files))
+        assert len(
+            files
+        ) == num_files, "The file directory should include {} compressed files, but there is only {}".format(
+            num_files, len(files))
 
         for f in files:
             extract_path = os.path.join(self.raw_data_path,
@@ -161,7 +164,7 @@ class Prep:
         # validate nii.gz on lung and mri with correct spacing_resample
         if filename.endswith((".nii", ".nii.gz", ".dcm")):
             if "radiopaedia" in filename or "corona" in filename:
-                 f_nps = [nib.load(f).get_fdata(dtype=np.float32)]
+                f_nps = [nib.load(f).get_fdata(dtype=np.float32)]
             else:
                 itkimage = sitk.ReadImage(f)
                 if itkimage.GetDimension() == 4:
@@ -232,8 +235,8 @@ class Prep:
                         ["images", "labels", "images_test"][i])):
 
                 # load data will transpose the image from "zyx" to "xyz"
-                spacing = dataset_json_dict["training"][
-                            osp.basename(f).split(".")[0]]["spacing"] if i == 0 else None
+                spacing = dataset_json_dict["training"][osp.basename(f).split(
+                    ".")[0]]["spacing"] if i == 0 else None
                 f_nps = Prep.load_medical_data(f)
 
                 for volume_idx, f_np in enumerate(f_nps):

--- a/contrib/MedicalSeg/tools/prepare_mri_spine_seg.py
+++ b/contrib/MedicalSeg/tools/prepare_mri_spine_seg.py
@@ -100,32 +100,32 @@ class Prep_mri_spine(Prep):
 if __name__ == "__main__":
     prep = Prep_mri_spine()
     prep.generate_dataset_json(
-            modalities=('MRI-T2', ),
-            labels={
-                0: "Background",
-                1: "S",
-                2: "L5",
-                3: "L4",
-                4: "L3",
-                5: "L2",
-                6: "L1",
-                7: "T12",
-                8: "T11",
-                9: "T10",
-                10: "T9",
-                11: "L5/S",
-                12: "L4/L5",
-                13: "L3/L4",
-                14: "L2/L3",
-                15: "L1/L2",
-                16: "T12/L1",
-                17: "T11/T12",
-                18: "T10/T11",
-                19: "T9/T10"
-            },
-            dataset_name="MRISpine Seg",
-            dataset_description="There are 172 training data in the preliminary competition, including MR images and mask labels, 20 test data in the preliminary competition and 23 test data in the  second round competition. The labels of the preliminary competition testset and the second round competition testset are not published, and the results can be evaluated online on this website.",
-            license_desc="https://www.spinesegmentation-challenge.com/wp-content/uploads/2021/12/Term-of-use.pdf",
-            dataset_reference="https://www.spinesegmentation-challenge.com/", )
+        modalities=('MRI-T2', ),
+        labels={
+            0: "Background",
+            1: "S",
+            2: "L5",
+            3: "L4",
+            4: "L3",
+            5: "L2",
+            6: "L1",
+            7: "T12",
+            8: "T11",
+            9: "T10",
+            10: "T9",
+            11: "L5/S",
+            12: "L4/L5",
+            13: "L3/L4",
+            14: "L2/L3",
+            15: "L1/L2",
+            16: "T12/L1",
+            17: "T11/T12",
+            18: "T10/T11",
+            19: "T9/T10"
+        },
+        dataset_name="MRISpine Seg",
+        dataset_description="There are 172 training data in the preliminary competition, including MR images and mask labels, 20 test data in the preliminary competition and 23 test data in the  second round competition. The labels of the preliminary competition testset and the second round competition testset are not published, and the results can be evaluated online on this website.",
+        license_desc="https://www.spinesegmentation-challenge.com/wp-content/uploads/2021/12/Term-of-use.pdf",
+        dataset_reference="https://www.spinesegmentation-challenge.com/", )
     prep.load_save()
     prep.generate_txt()

--- a/contrib/MedicalSeg/tools/preprocess_utils/values.py
+++ b/contrib/MedicalSeg/tools/preprocess_utils/values.py
@@ -76,7 +76,7 @@ def HUnorm(image, HU_min=-1200, HU_max=600, HU_nan=-2000):
     HU_nan: float, value for nan in the raw CT image.
     """
 
-    if not isinstance(image, np.ndarray): 
+    if not isinstance(image, np.ndarray):
         image = np.array(image)
     image = np.nan_to_num(image, copy=False, nan=HU_nan)
 


### PR DESCRIPTION
### 主要改动

重写了MedicalSeg部分的TIPC脚本，解决先前存在的如`${model_name}`提取行号不正确、大量配置文件选项被绕过且未给出任何警告、inference部分不记录执行状态等问题。

目前MedicalSeg部分的TIPC脚本与PaddleSeg主仓库TIPC脚本（只比较基础训推链条）存在的主要区别如下：
1. MedicalSeg的TIPC脚本不包含[`parse_extra_args()`](https://github.com/PaddlePaddle/PaddleSeg/blob/5aad8d59d2f34f1975d62507a743eaa53e6c5555/test_tipc/test_train_inference_python.sh#L133)功能；
2. MedicalSeg的TIPC脚本不支持AMP训练，因此配置文件中指定的`--precision`选项会被绕过，并给出一条警告；
3. 模型导出和推理使用的是`best_model/`子目录下的模型，而不是最后一次迭代对应的模型；
4. UNETR模型在训练时只使用单卡，推理时不使用CPU，也不启用MKL-DNN。

其中第2、3、4条是为了使修改后的脚本与修改前执行效果一致；第1条则是考虑到目前MedicalSeg的TIPC脚本还无需添加`parse_extra_args()`这样较为复杂的功能。

### 其它改动

修复了MedicalSeg中一部分脚本存在的格式问题。

### 待解决问题

在调试中发现UNETR的TIPC部分存在如下问题：
1. 验证时需要的内存太大，动态图跑eval的话1块16G的V100也不够用；
2. 无法支持MKL-DNN，若强行启用会报卷积输入形状错误。