### PR TITLE
[TIPC] add scripts for xpu and npu, test=develop

### DIFF
--- a/deploy/python/infer.py
+++ b/deploy/python/infer.py
@@ -61,7 +61,7 @@ def parse_args():
         default='./output')
     parser.add_argument(
         '--device',
-        choices=['cpu', 'gpu'],
+        choices=['cpu', 'gpu', 'xpu', 'npu'],
         default="gpu",
         help="Select which device to inference, defaults to gpu.")
 
@@ -243,6 +243,10 @@ class Predictor:
 
         if args.device == 'cpu':
             self._init_cpu_config()
+        elif args.device == 'npu':
+            self.pred_cfg.enable_npu()
+        elif args.device == 'xpu':
+            self.pred_cfg.enable_xpu()
         else:
             self._init_gpu_config()
 

--- a/paddleseg/models/layers/layer_libs.py
+++ b/paddleseg/models/layers/layer_libs.py
@@ -22,7 +22,9 @@ from paddleseg.models import layers
 
 def SyncBatchNorm(*args, **kwargs):
     """In cpu environment nn.SyncBatchNorm does not have kernel so use nn.BatchNorm2D instead"""
-    if paddle.get_device() == 'cpu' or os.environ.get('PADDLESEG_EXPORT_STAGE'):
+    if paddle.get_device() == 'cpu' or os.environ.get(
+            'PADDLESEG_EXPORT_STAGE') or 'xpu' in paddle.get_device(
+            ) or 'npu' in paddle.get_device():
         return nn.BatchNorm2D(*args, **kwargs)
     elif paddle.distributed.ParallelEnv().nranks == 1:
         return nn.BatchNorm2D(*args, **kwargs)

--- a/test_tipc/configs/bisenetv1/train_infer_python.txt
+++ b/test_tipc/configs/bisenetv1/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/bisenetv1/bisenetv1_resnet18_os8_cityscapes_1024x512_160k.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/bisenetv1/bisenetv1_resnet18_os8_cityscapes_1024x512_160k.yml --device gpu --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/test_tipc/configs/bisenetv2/train_infer_python.txt
+++ b/test_tipc/configs/bisenetv2/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/bisenetv2/bisenet_cityscapes_1024x1024_160k.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/bisenetv2/bisenet_cityscapes_1024x1024_160k.yml --device gpu --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/test_tipc/configs/ccnet/train_infer_python.txt
+++ b/test_tipc/configs/ccnet/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/ccnet/ccnet_resnet101_os8_cityscapes_769x769_60k.yml --save_interval 500 --seed 100 
+norm_train:train.py --config test_tipc/configs/ccnet/ccnet_resnet101_os8_cityscapes_769x769_60k.yml --device gpu --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null
@@ -21,7 +21,7 @@ null:null
 null:null
 ##
 ===========================eval_params===========================
-eval:val.py --config test_tipc/configs/ccnet/ccnet_resnet101_os8_cityscapes_769x769_60k.yml
+eval:val.py --config test_tipc/configs/ccnet/ccnet_resnet101_os8_cityscapes_769x769_60k.yml --device gpu
 null:null
 ##
 ===========================export_params===========================

--- a/test_tipc/configs/ddrnet/train_infer_python.txt
+++ b/test_tipc/configs/ddrnet/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/ddrnet/ddrnet23_cityscapes_1024x1024_120k.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/ddrnet/ddrnet23_cityscapes_1024x1024_120k.yml --device gpu --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/test_tipc/configs/deeplabv3p_resnet50/train_infer_python.txt
+++ b/test_tipc/configs/deeplabv3p_resnet50/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/mini_supervisely/test.txt
 --profiler_options:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/deeplabv3p_resnet50/deeplabv3p_resnet50_humanseg_512x512_mini_supervisely.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/deeplabv3p_resnet50/deeplabv3p_resnet50_humanseg_512x512_mini_supervisely.yml --device gpu --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/test_tipc/configs/deeplabv3p_resnet50_cityscapes/train_infer_python.txt
+++ b/test_tipc/configs/deeplabv3p_resnet50_cityscapes/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/deeplabv3p_resnet50_cityscapes/deeplabv3p_resnet50_1024x512_cityscapes.yml --save_interval 500 --seed 100 --num_workers 8 --log_iters 5
+norm_train:train.py --config test_tipc/configs/deeplabv3p_resnet50_cityscapes/deeplabv3p_resnet50_1024x512_cityscapes.yml --device gpu --save_interval 500 --seed 100 --num_workers 8 --log_iters 5
 pact_train:null
 fpgm_train:null
 distill_train:null
@@ -21,7 +21,7 @@ null:null
 null:null
 ##
 ===========================eval_params===========================
-eval:val.py --config test_tipc/configs/deeplabv3p_resnet50_cityscapes/deeplabv3p_resnet50_1024x512_cityscapes.yml --num_workers 8
+eval:val.py --config test_tipc/configs/deeplabv3p_resnet50_cityscapes/deeplabv3p_resnet50_1024x512_cityscapes.yml --device gpu --num_workers 8
 null:null
 ##
 ===========================export_params===========================

--- a/test_tipc/configs/encnet/train_infer_python.txt
+++ b/test_tipc/configs/encnet/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/encnet/encnet_resnet101_os8_cityscapes_1024x512_80k.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/encnet/encnet_resnet101_os8_cityscapes_1024x512_80k.yml --device gpu --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/test_tipc/configs/enet/train_infer_python.txt
+++ b/test_tipc/configs/enet/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/enet/enet_cityscapes_1024x512_adam_0.002_80k.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/enet/enet_cityscapes_1024x512_adam_0.002_80k.yml --device gpu --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/test_tipc/configs/espnetv2/train_infer_python.txt
+++ b/test_tipc/configs/espnetv2/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/espnetv2/espnet_cityscapes_1024x512_120k.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/espnetv2/espnet_cityscapes_1024x512_120k.yml --device gpu --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/test_tipc/configs/fastscnn/train_infer_python.txt
+++ b/test_tipc/configs/fastscnn/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 --profiler_options:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/fastscnn/fastscnn_cityscapes.yml --save_interval 500 --seed 100 --num_workers 8
+norm_train:train.py --config test_tipc/configs/fastscnn/fastscnn_cityscapes.yml --device gpu --save_interval 500 --seed 100 --num_workers 8
 pact_train:null
 fpgm_train:null
 distill_train:null
@@ -21,7 +21,7 @@ null:null
 null:null
 ##
 ===========================eval_params===========================
-eval:val.py --config test_tipc/configs/fastscnn/fastscnn_cityscapes.yml --num_workers 8
+eval:val.py --config test_tipc/configs/fastscnn/fastscnn_cityscapes.yml --device gpu --num_workers 8
 null:null
 ##
 ===========================export_params===========================

--- a/test_tipc/configs/fcn_hrnetw18/train_infer_python.txt
+++ b/test_tipc/configs/fcn_hrnetw18/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 --profiler_options:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/fcn_hrnetw18/fcn_hrnetw18_1024x512_cityscapes.yml --save_interval 500 --seed 100 --num_workers 8
+norm_train:train.py --config test_tipc/configs/fcn_hrnetw18/fcn_hrnetw18_1024x512_cityscapes.yml --device gpu --save_interval 500 --seed 100 --num_workers 8
 pact_train:null
 fpgm_train:null
 distill_train:null
@@ -21,7 +21,7 @@ null:null
 null:null
 ##
 ===========================eval_params===========================
-eval:val.py --config test_tipc/configs/fcn_hrnetw18/fcn_hrnetw18_1024x512_cityscapes.yml --num_workers 8
+eval:val.py --config test_tipc/configs/fcn_hrnetw18/fcn_hrnetw18_1024x512_cityscapes.yml --device gpu --num_workers 8
 null:null
 ##
 ===========================export_params===========================

--- a/test_tipc/configs/fcn_hrnetw18_small/train_infer_python.txt
+++ b/test_tipc/configs/fcn_hrnetw18_small/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/mini_supervisely/test.txt
 --profiler_options:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/fcn_hrnetw18_small/fcn_hrnetw18_small_v1_humanseg_192x192_mini_supervisely.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/fcn_hrnetw18_small/fcn_hrnetw18_small_v1_humanseg_192x192_mini_supervisely.yml --device gpu --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/test_tipc/configs/glore/train_infer_python.txt
+++ b/test_tipc/configs/glore/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/glore/glore_resnet50_os8_cityscapes_1024x512_80k.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/glore/glore_resnet50_os8_cityscapes_1024x512_80k.yml --device gpu --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/test_tipc/configs/hrnet_w48_contrast/train_infer_python.txt
+++ b/test_tipc/configs/hrnet_w48_contrast/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/hrnet_w48_contrast/HRNet_W48_contrast_cityscapes_1024x512_60k.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/hrnet_w48_contrast/HRNet_W48_contrast_cityscapes_1024x512_60k.yml --device gpu --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/test_tipc/configs/mobileseg_mv3/train_infer_python.txt
+++ b/test_tipc/configs/mobileseg_mv3/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/mobileseg_mv3/mobileseg_mobilenetv3_cityscapes_1024x512_80k.yml --save_interval 500 --seed 100 --num_workers 8
+norm_train:train.py --config test_tipc/configs/mobileseg_mv3/mobileseg_mobilenetv3_cityscapes_1024x512_80k.yml --device gpu --save_interval 500 --seed 100 --num_workers 8
 pact_train:null
 fpgm_train:null
 distill_train:null
@@ -21,7 +21,7 @@ null:null
 null:null
 ##
 ===========================eval_params===========================
-eval:val.py --config test_tipc/configs/mobileseg_mv3/mobileseg_mobilenetv3_cityscapes_1024x512_80k.yml --num_workers 8
+eval:val.py --config test_tipc/configs/mobileseg_mv3/mobileseg_mobilenetv3_cityscapes_1024x512_80k.yml --device gpu --num_workers 8
 null:null
 ##
 ===========================export_params===========================

--- a/test_tipc/configs/ocrnet_hrnetw18/train_infer_python.txt
+++ b/test_tipc/configs/ocrnet_hrnetw18/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 --profiler_options:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/ocrnet_hrnetw18/ocrnet_hrnetw18_cityscapes_1024x512_160k.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/ocrnet_hrnetw18/ocrnet_hrnetw18_cityscapes_1024x512_160k.yml --device gpu --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/test_tipc/configs/ocrnet_hrnetw48/train_infer_python.txt
+++ b/test_tipc/configs/ocrnet_hrnetw48/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 --profiler_options:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x512.yml --save_interval 500 --seed 100  --num_workers 8
+norm_train:train.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x512.yml --device gpu --save_interval 500 --seed 100  --num_workers 8
 pact_train:null
 fpgm_train:null
 distill_train:null
@@ -21,7 +21,7 @@ null:null
 null:null
 ##
 ===========================eval_params===========================
-eval:val.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x512.yml --num_workers 8
+eval:val.py --config test_tipc/configs/ocrnet_hrnetw48/ocrnet_hrnetw48_cityscapes_1024x512.yml --device gpu --num_workers 8
 null:null
 ##
 ===========================export_params===========================

--- a/test_tipc/configs/pfpnnet/train_infer_python.txt
+++ b/test_tipc/configs/pfpnnet/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/pfpnnet/pfpn_resnet101_os8_cityscapes_512x1024_40k.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/pfpnnet/pfpn_resnet101_os8_cityscapes_512x1024_40k.yml --device gpu --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/test_tipc/configs/pp_liteseg_stdc1/train_infer_python.txt
+++ b/test_tipc/configs/pp_liteseg_stdc1/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 --profiler_options:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/pp_liteseg_stdc1/pp_liteseg_stdc1_cityscapes_1024x512_160k.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/pp_liteseg_stdc1/pp_liteseg_stdc1_cityscapes_1024x512_160k.yml --device gpu --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/test_tipc/configs/pp_liteseg_stdc2/train_infer_python.txt
+++ b/test_tipc/configs/pp_liteseg_stdc2/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 --profiler_options:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/pp_liteseg_stdc2/pp_liteseg_stdc2_cityscapes_1024x512_160k.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/pp_liteseg_stdc2/pp_liteseg_stdc2_cityscapes_1024x512_160k.yml --device gpu --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/test_tipc/configs/pphumanseg_lite/train_infer_python.txt
+++ b/test_tipc/configs/pphumanseg_lite/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/mini_supervisely/test.txt
 --profiler_options:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/pphumanseg_lite/pphumanseg_lite_mini_supervisely.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/pphumanseg_lite/pphumanseg_lite_mini_supervisely.yml --device gpu --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/test_tipc/configs/ppmatting/train_infer_python.txt
+++ b/test_tipc/configs/ppmatting/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/PPM-100/val.txt
 --profiler_options:null
 ##
 trainer:norm
-norm_train:Matting/tools/train.py --config test_tipc/configs/ppmatting/modnet_mobilenetv2.yml --do_eval --save_interval 500 --seed 100
+norm_train:Matting/tools/train.py --config test_tipc/configs/ppmatting/modnet_mobilenetv2.yml --device gpu --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/test_tipc/configs/segformer_b0/train_infer_python.txt
+++ b/test_tipc/configs/segformer_b0/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/segformer_b0/segformer_b0_cityscapes_1024x1024_160k.yml --save_interval 500 --seed 100 --num_workers 8
+norm_train:train.py --config test_tipc/configs/segformer_b0/segformer_b0_cityscapes_1024x1024_160k.yml --device gpu --save_interval 500 --seed 100 --num_workers 8
 pact_train:null
 fpgm_train:null
 distill_train:null
@@ -21,7 +21,7 @@ null:null
 null:null
 ##
 ===========================eval_params===========================
-eval:val.py --config test_tipc/configs/segformer_b0/segformer_b0_cityscapes_1024x1024_160k.yml --num_workers 8
+eval:val.py --config test_tipc/configs/segformer_b0/segformer_b0_cityscapes_1024x1024_160k.yml --device gpu --num_workers 8
 null:null
 ##
 ===========================export_params===========================

--- a/test_tipc/configs/sfnet/train_infer_python.txt
+++ b/test_tipc/configs/sfnet/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/sfnet/sfnet_resnet18_os8_cityscapes_1024x1024_80k.yml --save_interval 500 --seed 100 --num_workers 8
+norm_train:train.py --config test_tipc/configs/sfnet/sfnet_resnet18_os8_cityscapes_1024x1024_80k.yml --device gpu --save_interval 500 --seed 100 --num_workers 8
 pact_train:null
 fpgm_train:null
 distill_train:null
@@ -21,7 +21,7 @@ null:null
 null:null
 ##
 ===========================eval_params===========================
-eval:val.py --config test_tipc/configs/sfnet/sfnet_resnet18_os8_cityscapes_1024x1024_80k.yml --num_workers 8
+eval:val.py --config test_tipc/configs/sfnet/sfnet_resnet18_os8_cityscapes_1024x1024_80k.yml --device gpu --num_workers 8
 null:null
 ##
 ===========================export_params===========================

--- a/test_tipc/configs/stdc_stdc1/train_infer_python.txt
+++ b/test_tipc/configs/stdc_stdc1/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/stdc_stdc1/stdc1_seg_cityscapes_1024x512_80k.yml --do_eval --save_interval 500 --seed 100
+norm_train:train.py --config test_tipc/configs/stdc_stdc1/stdc1_seg_cityscapes_1024x512_80k.yml --device gpu --do_eval --save_interval 500 --seed 100
 pact_train:null
 fpgm_train:null
 distill_train:null

--- a/test_tipc/configs/upernet/train_infer_python.txt
+++ b/test_tipc/configs/upernet/train_infer_python.txt
@@ -13,7 +13,7 @@ train_infer_img_dir:test_tipc/data/cityscapes/cityscapes_val_5.list
 null:null
 ##
 trainer:norm
-norm_train:train.py --config test_tipc/configs/upernet/upernet_resnet101_os8_cityscapes_512x1024_40k.yml --save_interval 500 --seed 100  --num_workers 8
+norm_train:train.py --config test_tipc/configs/upernet/upernet_resnet101_os8_cityscapes_512x1024_40k.yml --device gpu --save_interval 500 --seed 100  --num_workers 8
 pact_train:null
 fpgm_train:null
 distill_train:null
@@ -21,7 +21,7 @@ null:null
 null:null
 ##
 ===========================eval_params===========================
-eval:val.py --config test_tipc/configs/upernet/upernet_resnet101_os8_cityscapes_512x1024_40k.yml --num_workers 8
+eval:val.py --config test_tipc/configs/upernet/upernet_resnet101_os8_cityscapes_512x1024_40k.yml --device gpu --num_workers 8
 null:null
 ##
 ===========================export_params===========================

--- a/test_tipc/test_train_inference_python.sh
+++ b/test_tipc/test_train_inference_python.sh
@@ -366,9 +366,9 @@ else
                 if [ ${#gpu} -le 2 ];then  # train with cpu or single gpu
                     cmd="${python} ${run_train} ${set_use_gpu}  ${set_save_model} ${set_epoch} ${set_pretrain} ${set_autocast} ${set_batchsize} ${set_train_params1} ${set_amp_config}"
                 elif [ ${#ips} -le 15 ];then  # train with multi-gpu
-                    cmd="${python} -m paddle.distributed.launch --gpus=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_epoch} ${set_pretrain} ${set_autocast} ${set_batchsize} ${set_train_params1} ${set_amp_config}"
+                    cmd="${python} -m paddle.distributed.launch --devices=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_epoch} ${set_pretrain} ${set_autocast} ${set_batchsize} ${set_train_params1} ${set_amp_config}"
                 else     # train with multi-machine
-                    cmd="${python} -m paddle.distributed.launch --ips=${ips} --gpus=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_pretrain} ${set_epoch} ${set_autocast} ${set_batchsize} ${set_train_params1} ${set_amp_config}"
+                    cmd="${python} -m paddle.distributed.launch --ips=${ips} --devices=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_pretrain} ${set_epoch} ${set_autocast} ${set_batchsize} ${set_train_params1} ${set_amp_config}"
                 fi
                 
                 if [ "${MODE}" = 'benchmark_train' ] && [ -n "${log_iters}" ];then

--- a/test_tipc/test_train_inference_python_npu.sh
+++ b/test_tipc/test_train_inference_python_npu.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+source test_tipc/common_func.sh
+
+FILENAME=$1
+
+# disable mkldnn on non x86_64 env
+arch=$(uname -i)
+if [ $arch != "x86_64" ]; then
+    sed -i "s/--enable_mkldnn:True|False/--enable_mkldnn:False/g" $FILENAME
+    sed -i "s/--enable_mkldnn:True/--enable_mkldnn:False/g" $FILENAME
+fi
+
+# change gpu to npu in tipc txt configs
+sed -i "s/Global.use_gpu/Global.use_npu/g" $FILENAME
+sed -i "s/--device gpu/--device npu/g" $FILENAME
+sed -i "s/--device:cpu|gpu/--device:cpu|npu/g" $FILENAME
+# disable benchmark as AutoLog required nvidia-smi command
+sed -i "s/--benchmark:True/--benchmark:False/g" $FILENAME
+dataline=`cat $FILENAME`
+
+# change gpu to npu in execution script
+sed -i "s/\"gpu\"/\"npu\"/g" test_tipc/test_train_inference_python.sh
+
+# pass parameters to test_train_inference_python.sh
+cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} $2"
+echo -e "\033[1;32m Started to run command: ${cmd}!  \033[0m"
+eval $cmd

--- a/test_tipc/test_train_inference_python_xpu.sh
+++ b/test_tipc/test_train_inference_python_xpu.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+source test_tipc/common_func.sh
+
+FILENAME=$1
+
+# disable mkldnn on non x86_64 env
+arch=$(uname -i)
+if [ $arch != "x86_64" ]; then
+    sed -i "s/--enable_mkldnn:True|False/--enable_mkldnn:False/g" $FILENAME
+    sed -i "s/--enable_mkldnn:True/--enable_mkldnn:False/g" $FILENAME
+fi
+
+# change gpu to xpu in tipc txt configs
+sed -i "s/Global.use_gpu/Global.use_xpu/g" $FILENAME
+sed -i "s/--device gpu/--device xpu/g" $FILENAME
+sed -i "s/--device:cpu|gpu/--device:cpu|xpu/g" $FILENAME
+# disable benchmark as AutoLog required nvidia-smi command
+sed -i "s/--benchmark:True/--benchmark:False/g" $FILENAME
+dataline=`cat $FILENAME`
+
+# change gpu to xpu in execution script
+sed -i "s/\"gpu\"/\"xpu\"/g" test_tipc/test_train_inference_python.sh
+
+# pass parameters to test_train_inference_python.sh
+cmd="bash test_tipc/test_train_inference_python.sh ${FILENAME} $2"
+echo -e "\033[1;32m Started to run command: ${cmd}!  \033[0m"
+eval $cmd


### PR DESCRIPTION
为昇腾和昆仑设备添加 TIPC 脚本

```bash
# 准备小数据集
bash test_tipc/prepare.sh \
     test_tipc/configs/deeplabv3p_resnet50/train_infer_python.txt 'lite_train_lite_infer'


# GPU上运行单测模型，脚本保持不变
bash test_tipc/test_train_inference_python.sh \
     test_tipc/configs/deeplabv3p_resnet50/train_infer_python.txt 'lite_train_lite_infer'

# NPU上运行单测模型，注意这里的脚本带 _npu.sh 后缀
bash test_tipc/test_train_inference_python_npu.sh \
     test_tipc/configs/deeplabv3p_resnet50/train_infer_python.txt 'lite_train_lite_infer'

# XPU上运行单测模型，注意这里的脚本带 _xpu.sh 后缀
bash test_tipc/test_train_inference_python_xpu.sh \
     test_tipc/configs/deeplabv3p_resnet50/train_infer_python.txt 'lite_train_lite_infer'
```

其中 ` test_tipc/configs` 目录下所有的 txt 文件都只增加了 `--device gpu` 的参数输入
