### PR TITLE
Fix the ISSUE #2365,  fix the code error in PaddleSeg/deploy/python/infer.py

### DIFF
--- a/deploy/python/infer.py
+++ b/deploy/python/infer.py
@@ -390,7 +390,7 @@ class Predictor:
     def _preprocess(self, img):
         data = {}
         data['img'] = img
-        return self.cfg.transforms(data)['img']
+        return self.cfg.transforms(data['img'])[0]
 
     def _postprocess(self, results):
         if self.args.with_argmax:


### PR DESCRIPTION
Fix Issue #2365,  fix the code error in PaddleSeg/deploy/python/infer.py
[General Issue]deploy/python/infer.py \transforms.py", line 63, in __call__ cv2.error: OpenCV(4.6.0) 👎 error: (-5:Bad argument) in function 'cvtColor' #2365

