### PR TITLE
[Bug fix] Correct the use of dist.all_reduce

### DIFF
--- a/paddleseg/models/emanet.py
+++ b/paddleseg/models/emanet.py
@@ -209,9 +209,7 @@ class EMAU(nn.Layer):
             mu = F.normalize(mu, axis=1, p=2)
             mu = self.mu * (1 - self.momentum) + mu * self.momentum
             if paddle.distributed.get_world_size() > 1:
-                out = paddle.distributed.all_reduce(mu)
-                if out is not None:
-                    mu = out
+                paddle.distributed.all_reduce(mu)
                 mu /= paddle.distributed.get_world_size()
             self.mu = mu
 


### PR DESCRIPTION
新通信库下，通信后的结果会inplace的修改input，同时以task作为返回值。
在像下面的同步通信的语境下，不需要考虑返回的task。