### PR TITLE
[Fix] Fix dmnet export fail in conv layer

### DIFF
--- a/paddleseg/models/dmnet.py
+++ b/paddleseg/models/dmnet.py
@@ -129,7 +129,7 @@ class DCM(nn.Layer):
         generated_filter = self.filter_gen_conv(self.avg_pool(x))
         x = self.input_redu_conv(x)
         b, c, h, w = x.shape
-        x = x.reshape([1, b * c, h, w])
+        x = paddle.unsqueeze(paddle.flatten(x, start_axis=0, stop_axis=1), axis=0)
         generated_filter = generated_filter.reshape(
             [b * c, 1, self.filter_size, self.filter_size])
 

--- a/paddleseg/models/dmnet.py
+++ b/paddleseg/models/dmnet.py
@@ -129,6 +129,8 @@ class DCM(nn.Layer):
         generated_filter = self.filter_gen_conv(self.avg_pool(x))
         x = self.input_redu_conv(x)
         b, c, h, w = x.shape
+        assert b > 0, "The batch size of x need to be bigger than 0, but got {}.".format(
+            b)
         x = paddle.unsqueeze(
             paddle.flatten(
                 x, start_axis=0, stop_axis=1), axis=0)

--- a/paddleseg/models/dmnet.py
+++ b/paddleseg/models/dmnet.py
@@ -129,7 +129,9 @@ class DCM(nn.Layer):
         generated_filter = self.filter_gen_conv(self.avg_pool(x))
         x = self.input_redu_conv(x)
         b, c, h, w = x.shape
-        x = paddle.unsqueeze(paddle.flatten(x, start_axis=0, stop_axis=1), axis=0)
+        x = paddle.unsqueeze(
+            paddle.flatten(
+                x, start_axis=0, stop_axis=1), axis=0)
         generated_filter = generated_filter.reshape(
             [b * c, 1, self.filter_size, self.filter_size])
 


### PR DESCRIPTION
dmnet 动转静由于conv输入 channel 不能为负数报错如下：
![742a83ca60b460b5e2b82cdfc3aaf64c](https://user-images.githubusercontent.com/34859558/196081863-fcfb8a58-a96d-4153-8f71-2c55d23d78bd.png)


这是因为代码中需要将特征x的第0维度和第1维度整合，但是输入第0维度未知导致，因此修改代码之后需要指定shape输入，导出命令如下：
```python
python export.py --config configs/dmnet/dmnet_resnet101_os8_cityscapes_1024x512_80k.yml --save_dir log  --input_shape 1 3 1024 2048
```

经测试，可以成功导出，导出结果如下：
<img width="677" alt="image" src="https://user-images.githubusercontent.com/34859558/195484529-39ddaf66-9153-45a6-8f4d-fc7b273b8fac.png">


预测：
```python 
wget https://paddleseg.bj.bcebos.com/dygraph/demo/cityscapes_demo.png
python deploy/python/infer.py  --config log/deploy.yaml  --image_path cityscapes_demo.png 
```
<img width="799" alt="image" src="https://user-images.githubusercontent.com/34859558/196580269-ee000df8-193b-4a45-8198-283e49a01e7e.png">
