### PR TITLE
[TIPC] Fix TIPC Bugs

### DIFF
--- a/Matting/ppmatting/__init__.py
+++ b/Matting/ppmatting/__init__.py
@@ -1,1 +1,1 @@
-from . import ml, metrics, transforms, datasets, models
+from . import ml, metrics, transforms, datasets, models, utils

--- a/test_tipc/common_func.sh
+++ b/test_tipc/common_func.sh
@@ -112,7 +112,7 @@ function run_command() {
     local cmd="$1"
     local log_path="$2"
     if [ -n "${log_path}" ]; then
-        eval ${cmd} | tee "${log_path}"
+        eval ${cmd} 2>&1 | tee "${log_path}"
         test ${PIPESTATUS[0]} -eq 0
     else
         eval ${cmd}

--- a/test_tipc/configs/rtformer/train_infer_python.txt
+++ b/test_tipc/configs/rtformer/train_infer_python.txt
@@ -27,7 +27,7 @@ null:null
 ===========================export_params===========================
 --save_dir:
 --model_path:
-norm_export:tools/export.py --config test_tipc/configs/rtformer/rtformer_base_cityscapes_1024x512_120k.yml
+norm_export:tools/export.py --config test_tipc/configs/rtformer/rtformer_base_cityscapes_1024x512_120k.yml --input_shape 1 3 512 512
 quant_export:null
 fpgm_export:null
 distill_export:null


### PR DESCRIPTION
1. 修复日志中不记录标准错误流输出的问题；
2. 修复RTFormer导出时的形状bug；
3. 修复PP-Matting导出时找不到模块的bug。