### PR TITLE
[Feat] Automatically Limit cv2 Threads

### DIFF
--- a/tools/train.py
+++ b/tools/train.py
@@ -136,7 +136,7 @@ def parse_args():
     parser.add_argument(
         '--device',
         dest='device',
-        help='Device place to be set, which can be gpu, xpu, npu, or cpu.',
+        help='Device place to be set, which can be gpu, xpu, npu, mlu or cpu.',
         default='gpu',
         choices=['cpu', 'gpu', 'xpu', 'npu'],
         type=str)
@@ -151,7 +151,6 @@ def parse_args():
 
 
 def main(args):
-
     if args.seed is not None:
         paddle.seed(args.seed)
         np.random.seed(args.seed)
@@ -170,6 +169,8 @@ def main(args):
         place = 'xpu'
     elif args.device == 'npu' and paddle.is_compiled_with_npu():
         place = 'npu'
+    elif args.device == 'mlu' and paddle.is_compiled_with_mlu():
+        place = 'mlu'
     else:
         place = 'cpu'
 

--- a/tools/train.py
+++ b/tools/train.py
@@ -17,6 +17,7 @@ import random
 
 import paddle
 import numpy as np
+import cv2
 
 from paddleseg.cvlibs import manager, Config
 from paddleseg.utils import get_sys_env, logger
@@ -175,6 +176,15 @@ def main(args):
     paddle.set_device(place)
     if not args.cfg:
         raise RuntimeError('No configuration file specified.')
+
+    nranks = paddle.distributed.ParallelEnv().nranks
+    # Limit cv2 threads if too many subprocesses are spawned.
+    # This should reduce resource allocation and thus boost performance.
+    if nranks >= 8 and args.num_workers >= 8:
+        logger.warning(
+            "The number of threads used by OpenCV is set to 1 to improve performance."
+        )
+        cv2.setNumThreads(1)
 
     cfg = Config(
         args.cfg,

--- a/train.py
+++ b/train.py
@@ -17,6 +17,7 @@ import random
 
 import paddle
 import numpy as np
+import cv2
 
 from paddleseg.cvlibs import manager, Config
 from paddleseg.utils import get_sys_env, logger
@@ -176,6 +177,15 @@ def main(args):
     paddle.set_device(place)
     if not args.cfg:
         raise RuntimeError('No configuration file specified.')
+
+    nranks = paddle.distributed.ParallelEnv().nranks
+    # Limit cv2 threads if too many subprocesses are spawned.
+    # This should reduce resource allocation and thus boost performance.
+    if nranks >= 8 and args.num_workers >= 8:
+        logger.warning(
+            "The number of threads used by OpenCV is set to 1 to improve performance."
+        )
+        cv2.setNumThreads(1)
 
     cfg = Config(
         args.cfg,


### PR DESCRIPTION
## 问题
当使用八块以上GPU训练且设置num_workers>=8，若不对OpenCV允许使用的线程数做限制，则可能出现明显的性能下降（例如，对于MobileSeg-mv3模型，训练速度可降低18.27%）。

## 解决方案
在`train.py`脚本中增加对设备数和`num_workers`的判断，根据情况自动限制OpenCV线程数。