### PR TITLE
[TIPC] Fix Cpp Inference Bugs

### DIFF
--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -187,28 +187,28 @@ if [ ${MODE} = "cpp_infer" ];then
         wget -P inference_models https://paddleseg.bj.bcebos.com/dygraph/demo/pp_liteseg_infer_model.tar.gz --no-check-certificate
         tar xf inference_models/pp_liteseg_infer_model.tar.gz  -C inference_models
     elif [ ${model_name} == "pp_liteseg_stdc2" ];then
-        wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models/pp_liteseg_stdc2_cityscapes_1024x512_scale1.0_160k.zip --no-check-certificate
+        wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models_i32/pp_liteseg_stdc2_cityscapes_1024x512_scale1.0_160k.zip --no-check-certificate
         unzip inference_models/pp_liteseg_stdc2_cityscapes_1024x512_scale1.0_160k.zip -d inference_models/
     elif [ ${model_name} == "pphumanseg_lite" ];then
-        wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models/pp_humanseg_lite_export_398x224.zip --no-check-certificate
+        wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models_i32/pp_humanseg_lite_export_398x224.zip --no-check-certificate
         unzip inference_models/pp_humanseg_lite_export_398x224 -d inference_models/
     elif [ ${model_name} == "fcn_hrnetw18_small" ];then
-        wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models/pp_humanseg_mobile_export_192x192.zip --no-check-certificate
+        wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models_i32/pp_humanseg_mobile_export_192x192.zip --no-check-certificate
         unzip inference_models/pp_humanseg_mobile_export_192x192.zip -d inference_models/
     elif [ ${model_name} == "deeplabv3p_resnet50" ];then
-        wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models/pp_humanseg_server_export_512x512.zip --no-check-certificate
+        wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models_i32/pp_humanseg_server_export_512x512.zip --no-check-certificate
         unzip inference_models/pp_humanseg_server_export_512x512.zip -d inference_models/
     elif [ ${model_name} == "fcn_hrnetw18" ];then
-        wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models/fcn_hrnetw18_cityscapes_1024x512_80k.zip --no-check-certificate
+        wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models_i32/fcn_hrnetw18_cityscapes_1024x512_80k.zip --no-check-certificate
         unzip inference_models/fcn_hrnetw18_cityscapes_1024x512_80k.zip -d inference_models/
     elif [ ${model_name} == "ocrnet_hrnetw48" ];then
-        wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models/ocrnet_hrnetw48_cityscapes_1024x512_160k.zip --no-check-certificate
+        wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models_i32/ocrnet_hrnetw48_cityscapes_1024x512_160k.zip --no-check-certificate
         unzip inference_models/ocrnet_hrnetw48_cityscapes_1024x512_160k.zip -d inference_models/
     elif [ ${model_name} == "ocrnet_hrnetw18" ];then
-        wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models/ocrnet_hrnetw18_cityscapes_1024x512_160k.zip --no-check-certificate
+        wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models_i32/ocrnet_hrnetw18_cityscapes_1024x512_160k.zip --no-check-certificate
         unzip inference_models/ocrnet_hrnetw18_cityscapes_1024x512_160k.zip -d inference_models/
     elif [ ${model_name} == "segformer_b0" ];then
-        wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models/segformer_b0_cityscapes_1024x1024_160k.zip --no-check-certificate
+        wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models_i32/segformer_b0_cityscapes_1024x1024_160k.zip --no-check-certificate
         unzip inference_models/segformer_b0_cityscapes_1024x1024_160k.zip -d inference_models/
     fi
 


### PR DESCRIPTION
更新推理模型的下载目录，使用重新导出的int32类型输出的模型进行TIPC推理链条测试。