### PR TITLE
unet need sleep a longger time to wait dataloader release

### DIFF
--- a/paddleseg/core/train.py
+++ b/paddleseg/core/train.py
@@ -328,7 +328,7 @@ def train(model,
             model, [1, c, h, w],
             custom_ops={paddle.nn.SyncBatchNorm: op_flops_funs.count_syncbn})
 
-    # Sleep for half a second to let dataloader release resources.
-    time.sleep(0.5)
+    # Sleep for a second to let dataloader release resources.
+    time.sleep(1)
     if use_vdl:
         log_writer.close()


### PR DESCRIPTION
GPU、XPU中均在模型执行完程序退出时崩溃，经分析是DataLoader没有销毁完导致的。
本PR延长等待DataLoader销毁的时间。