### PR TITLE
[TIPC] Install Develop Version for Benchmark

### DIFF
--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -26,6 +26,12 @@ fi
 model_path=test_tipc/output/${model_name}/
 
 
+# Install dependencies
+pip install -r requirements.txt
+pip install -r test_tipc/requirements.txt
+# Install current version of PaddleSeg
+pip install -e .
+
 if [ ${MODE} = "serving_infer" ]; then
     inference_models=test_tipc/inferences/${model_name}/
     mkdir -p $inference_models
@@ -125,10 +131,6 @@ fi
 # download data
 mkdir -p ./test_tipc/data
 if [ ${MODE} = "benchmark_train" ];then
-    pip install -r requirements.txt
-    pip install -r test_tipc/requirements.txt
-    # Install current version of PaddleSeg
-    pip install -e .
     if [ ${model_name} = 'fcn_hrnetw18_small' ] \
         || [ ${model_name} = 'pphumanseg_lite' ] \
         || [ ${model_name} = 'deeplabv3p_resnet50' ] \

--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -127,6 +127,8 @@ mkdir -p ./test_tipc/data
 if [ ${MODE} = "benchmark_train" ];then
     pip install -r requirements.txt
     pip install -r test_tipc/requirements.txt
+    # Install current version of PaddleSeg
+    pip install -e .
     if [ ${model_name} = 'fcn_hrnetw18_small' ] \
         || [ ${model_name} = 'pphumanseg_lite' ] \
         || [ ${model_name} = 'deeplabv3p_resnet50' ] \

--- a/test_tipc/requirements.txt
+++ b/test_tipc/requirements.txt
@@ -8,7 +8,6 @@ tqdm
 filelock
 scipy
 prettytable
-paddleseg
 scikit-image
 numba
 pymatting


### PR DESCRIPTION
修改了`test_tipc/prepare.sh`脚本和`test_tipc/requirements.txt`，在执行TIPC脚本时安装当前本地的paddleseg版本（可能是develop版本），而不是从pypi下载最新的stable版本。