### PR TITLE
[EISeg] Fix bug(#2860)

### DIFF
--- a/EISeg/eiseg/app.py
+++ b/EISeg/eiseg/app.py
@@ -2076,19 +2076,11 @@ class APP_EISeg(QMainWindow, Ui_EISeg):
                         label["points"].append(p)
                     labels["shapes"].append(label)
 
-                if not osp.exists(
-                        osp.join(os.path.dirname(savePath), "labelme")):
-                    os.makedirs(osp.join(os.path.dirname(savePath), "labelme"))
-                ri = savePath.rindex('/')
-                fileName = savePath[ri + 1:]
-                savePath = osp.join(
-                    osp.join(os.path.dirname(savePath), "labelme"), fileName)
-
                 if self.origExt:
-                    jsonPath = savePath + "_labelme" + ".json"
+                    lmjsonPath = savePath + "_labelme.json"
                 else:
-                    jsonPath = osp.splitext(savePath)[0] + "_labelme" + ".json"
-                open(jsonPath, "w", encoding="utf-8").write(json.dumps(labels))
+                    lmjsonPath = osp.splitext(savePath)[0] + "_labelme.json"
+                open(lmjsonPath, "w", encoding="utf-8").write(json.dumps(labels))
 
                 label_path = osp.join(os.path.dirname(savePath), "labels.txt")
                 self.save_labelName_txt(path=label_path)


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others 

### Description
<!-- Describe what this PR does -->
#2860 提到的保存错误源于在保存新的‘_labelme.json’的时候在之前的label文件中新建了一个`labelme`文件夹，然后将数据保存在子文件夹中。但由于使用了`ri = savePath.rindex('/')`这个操作，在Windows中为'\\\\'，所以在Windows中路径出错。这个pr去掉了新建子文件夹操作，直接保存在和其他标注同样的文件夹中。