### PR TITLE
[Fix] `qat_export.py` Relies on Deprecated `export_config`

### DIFF
--- a/deploy/slim/quant/qat_export.py
+++ b/deploy/slim/quant/qat_export.py
@@ -92,7 +92,7 @@ def main(args):
 
     yml_file = os.path.join(args.save_dir, 'deploy.yaml')
     with open(yml_file, 'w') as file:
-        transforms = cfg.export_config.get('transforms', [{
+        transforms = cfg.val_dataset_config.get('transforms', [{
             'type': 'Normalize'
         }])
         data = {


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Others

### Description

修复 https://github.com/PaddlePaddle/PaddleSeg/pull/2893 导致的量化模型导出 bug。
