### PR TITLE
[Fix] HRNet TIPC Config Wrong Parameter Name

### DIFF
--- a/deploy/slim/quant/qat_export.py
+++ b/deploy/slim/quant/qat_export.py
@@ -92,7 +92,7 @@ def main(args):
 
     yml_file = os.path.join(args.save_dir, 'deploy.yaml')
     with open(yml_file, 'w') as file:
-        transforms = cfg.export_config.get('transforms', [{
+        transforms = cfg.val_dataset_config.get('transforms', [{
             'type': 'Normalize'
         }])
         data = {

--- a/paddleseg/cvlibs/builder.py
+++ b/paddleseg/cvlibs/builder.py
@@ -271,8 +271,10 @@ class SegBuilder(Builder):
             'No val_dataset specified in the configuration file.'
         self.show_msg('val_dataset', dataset_cfg)
         dataset = self.build_component(dataset_cfg)
-        assert len(dataset) != 0, \
-            'The number of samples in val_dataset is 0. Please check whether the dataset is valid.'
+        if len(dataset) == 0:
+            logger.warning(
+                'The number of samples in val_dataset is 0. Please ensure this is the desired behavior.'
+            )
         return dataset
 
     @cached_property

--- a/test_tipc/configs/hrnet_w48_contrast/HRNet_W48_contrast_cityscapes_1024x512_60k.yml
+++ b/test_tipc/configs/hrnet_w48_contrast/HRNet_W48_contrast_cityscapes_1024x512_60k.yml
@@ -24,6 +24,6 @@ model:
   backbone:
     type: HRNet_W48
     pretrained: https://bj.bcebos.com/paddleseg/dygraph/hrnet_w48_ssld.tar.gz
-  in_channels: 720
+  bb_channels: 720
   drop_prob: 0.1
   proj_dim: 720


### PR DESCRIPTION
### PR types
Bug fixes

### PR changes
Tests

### Description
1. 修复 #2897 修改 HRNet 输入参数名称导致的 TIPC 配置文件中参数命名错误。
2. 放松 builder 中不允许 val_dataset 长度为0的约束，检查后只发出警告而不抛出异常。这是考虑到部分 TIPC 模型在做 lite_train_lite_infer 时依赖于一个长度为0的 mini-Cityscapes 数据集。