### PR TITLE
fix 3 dead tutorial links in deploy/slim

### DIFF
--- a/deploy/slim/distill/README.md
+++ b/deploy/slim/distill/README.md
@@ -1,1 +1,1 @@
-Please refer to the [tutorial](../../docs/deployment/slim/distill/distill.md) for model distillation.
+Please refer to the [tutorial](../../../docs/deployment/slim/distill/distill.md) for model distillation.

--- a/deploy/slim/prune/README.md
+++ b/deploy/slim/prune/README.md
@@ -1,1 +1,1 @@
-Please refer to the [tutorial](../../docs/deployment/slim/prune/prune.md) for model pruning.
+Please refer to the [tutorial](../../../docs/deployment/slim/prune/prune.md) for model pruning.

--- a/deploy/slim/quant/README.md
+++ b/deploy/slim/quant/README.md
@@ -1,1 +1,1 @@
-Please refer to the [tutorial](../../docs/deployment/slim/quant/quant.md) for model quantization.
+Please refer to the [tutorial](../../../docs/deployment/slim/quant/quant.md) for model quantization.


### PR DESCRIPTION
### PR types
Others

### PR changes
Docs

### Description
fix 3 dead tutorial links in deploy/slim, which should also be cherrypicked to release 2.7.
