### PR TITLE
[Feat] Add `--opts` Support for Deploy Scripts

### DIFF
--- a/contrib/MedicalSeg/test_tipc/common_func.sh
+++ b/contrib/MedicalSeg/test_tipc/common_func.sh
@@ -19,9 +19,9 @@ function func_parser_value(){
 function func_set_params(){
     key=$1
     value=$2
-    if [ ${key}x = "null"x ];then
+    if [ ${key}x = "null"x ]; then
         echo " "
-    elif [[ ${value} = "null" ]] || [[ ${value} = " " ]] || [ ${#value} -le 0 ];then
+    elif [[ ${value} = "null" ]] || [[ ${value} = " " ]] || [ ${#value} -le 0 ]; then
         echo " "
     else
         echo "${key}=${value}"

--- a/contrib/MedicalSeg/test_tipc/prepare.sh
+++ b/contrib/MedicalSeg/test_tipc/prepare.sh
@@ -18,7 +18,7 @@ model_name=$(func_parser_value "${lines[1]}")
 trainer_list=$(func_parser_value "${lines[14]}")
 
 # MODE be one of ['lite_train_lite_infer']
-if [ ${MODE} = "lite_train_lite_infer" ];then
+if [ ${MODE} = "lite_train_lite_infer" ]; then
     if [ ${model_name} = "UNETR" ]; then
         mkdir -p ./test_tipc/data
         rm -rf ./test_tipc/data/mini_levir_dataset

--- a/contrib/MedicalSeg/test_tipc/test_train_inference_python.sh
+++ b/contrib/MedicalSeg/test_tipc/test_train_inference_python.sh
@@ -132,8 +132,8 @@ status_log="${LOG_PATH}/results_python.log"
 echo "------------------------ ${MODE} ------------------------" >> $status_log
 
 
-if [ "${MODE}" = 'benchmark_train' ];then
-    if [ "${autocast_key}" = 'Global.auto_cast' ];then
+if [ "${MODE}" = 'benchmark_train' ]; then
+    if [ "${autocast_key}" = 'Global.auto_cast' ]; then
         echo 'Replcace ${autocast_key}'"('${autocast_key}') with '--precision'"
         autocast_key="--precision"
     fi
@@ -229,7 +229,7 @@ function func_inference(){
 
 if [ ${MODE} = "whole_infer" ] || [ ${MODE} = "klquant_whole_infer" ]; then
     GPUID=$3
-    if [ ${#GPUID} -le 0 ];then
+    if [ ${#GPUID} -le 0 ]; then
         env=" "
     else
         env="export CUDA_VISIBLE_DEVICES=${GPUID}"
@@ -242,7 +242,7 @@ if [ ${MODE} = "whole_infer" ] || [ ${MODE} = "klquant_whole_infer" ]; then
     infer_quant_flag=(${infer_is_quant})
     for infer_model in ${infer_model_dir_list[*]}; do
         # run export
-        if [ ${infer_run_exports[Count]} != "null" ];then
+        if [ ${infer_run_exports[Count]} != "null" ]; then
             save_infer_dir=$(dirname $infer_model)
             set_export_weight=$(func_set_params "${export_weight}" "${infer_model}")
             set_save_infer_key=$(func_set_params "${save_infer_key}" "${save_infer_dir}")
@@ -270,12 +270,12 @@ else
         train_use_gpu=${USE_GPU_KEY[Count]}
         Count=$(($Count + 1))
         ips=""
-        if [ ${gpu} = "-1" ];then
+        if [ ${gpu} = "-1" ]; then
             env=""
-        elif [ ${#gpu} -le 1 ];then
+        elif [ ${#gpu} -le 1 ]; then
             env="export CUDA_VISIBLE_DEVICES=${gpu}"
             eval ${env}
-        elif [ ${#gpu} -le 15 ];then
+        elif [ ${#gpu} -le 15 ]; then
             IFS=","
             array=(${gpu})
             env="export CUDA_VISIBLE_DEVICES=${array[0]}"
@@ -291,7 +291,7 @@ else
         for autocast in ${autocast_list[*]}; do
             if [ ${autocast} = "amp" ]; then
                 set_amp_config="Global.use_amp=True Global.scale_loss=1024.0 Global.use_dynamic_loss_scaling=True"
-            elif [ "${autocast}" = 'fp16' ] && [ "${MODE}" = 'benchmark_train' ];then
+            elif [ "${autocast}" = 'fp16' ] && [ "${MODE}" = 'benchmark_train' ]; then
                 set_amp_config="--amp_level=O2"
             else
                 set_amp_config=" "
@@ -330,7 +330,7 @@ else
                 set_use_gpu=$(func_set_params "${train_use_gpu_key}" "${train_use_gpu}")
                 # if length of ips >= 15, then it is seen as multi-machine
                 # 15 is the min length of ips info for multi-machine: 0.0.0.0,0.0.0.0
-                if [ ${#ips} -le 15 ];then
+                if [ ${#ips} -le 15 ]; then
                     save_log="${LOG_PATH}/${trainer}_gpus_${gpu}_autocast_${autocast}"
                     nodes=1
                 else
@@ -353,23 +353,23 @@ else
                 fi
 
                 set_save_model=$(func_set_params "${save_model_key}" "${save_log}")
-                if [ ${#gpu} -le 2 ];then  # train with cpu or single gpu
+                if [ ${#gpu} -le 2 ]; then  # train with cpu or single gpu
                     cmd="${python} ${run_train} ${set_use_gpu}  ${set_save_model} ${set_epoch} ${set_pretrain} ${set_autocast} ${set_batchsize} ${set_train_params1} ${set_amp_config}"
-                elif [ ${#ips} -le 15 ];then  # train with multi-gpu
+                elif [ ${#ips} -le 15 ]; then  # train with multi-gpu
                     cmd="${python} -m paddle.distributed.launch --gpus=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_epoch} ${set_pretrain} ${set_autocast} ${set_batchsize} ${set_train_params1} ${set_amp_config}"
                 else     # train with multi-machine
                     cmd="${python} -m paddle.distributed.launch --ips=${ips} --gpus=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_pretrain} ${set_epoch} ${set_autocast} ${set_batchsize} ${set_train_params1} ${set_amp_config}"
                 fi
                 
-                if [ -n "${log_iters}" ];then
+                if [ -n "${log_iters}" ]; then
                     cmd="${cmd} --log_iters ${log_iters}"
                 fi
 
-                if [ -n "${amp_level}" ];then
+                if [ -n "${amp_level}" ]; then
                     cmd="${cmd} --amp_level ${amp_level}"
                 fi
 
-                if [ -n "${set_cv_threads}" ] && [ "${set_cv_threads}" = "true" ];then
+                if [ -n "${set_cv_threads}" ] && [ "${set_cv_threads}" = "true" ]; then
                     # Take the first word as the training script, which means there should be no blanks in the path of script.
                     train_script=$(echo "${run_train}" | cut -d ' ' -f1)
                     # Make a copy
@@ -385,11 +385,11 @@ else
                 run_command "${cmd}" "${log_path}"
                 status_check $? "${cmd}" "${status_log}" "${model_name}"
 
-                if [[ "$cmd" == *'paddle.distributed.launch'* ]]; then
+                if [[ "$cmd" = *'paddle.distributed.launch'* ]]; then
                     cat log/workerlog.0 >> ${log_path} 
                 fi
 
-                if [ -n "${set_cv_threads}" ] && [ "${set_cv_threads}" = "true" ];then
+                if [ -n "${set_cv_threads}" ] && [ "${set_cv_threads}" = "true" ]; then
                     rm ${train_script_copy}
                 fi
 

--- a/contrib/PanopticSeg/test_tipc/common_func.sh
+++ b/contrib/PanopticSeg/test_tipc/common_func.sh
@@ -28,9 +28,9 @@ function func_set_params() {
     local key=$1
     local value=$2
     local sep="${3-=}"
-    if [ ${key}x = "null"x ];then
+    if [ ${key}x = "null"x ]; then
         echo " "
-    elif [[ ${value} = "null" ]] || [[ ${value} = " " ]] || [ ${#value} -le 0 ];then
+    elif [[ ${value} = "null" ]] || [[ ${value} = " " ]] || [ ${#value} -le 0 ]; then
         echo " "
     else 
         echo "${key}${sep}${value}"

--- a/contrib/PanopticSeg/test_tipc/prepare.sh
+++ b/contrib/PanopticSeg/test_tipc/prepare.sh
@@ -33,13 +33,13 @@ fi
 # Download datasets
 DATA_DIR='./test_tipc/data/'
 mkdir -p "${DATA_DIR}"
-if [[ ${MODE} == 'lite_train_lite_infer' \
-    || ${MODE} == 'lite_train_whole_infer' \
-    || ${MODE} == 'whole_infer' ]]; then
+if [[ ${MODE} = 'lite_train_lite_infer' \
+    || ${MODE} = 'lite_train_whole_infer' \
+    || ${MODE} = 'whole_infer' ]]; then
 
     download_and_unzip_dataset "${DATA_DIR}" coco https://paddleseg.bj.bcebos.com/dataset/mini_coco_panseg.zip
 
-elif [[ ${MODE} == 'whole_train_whole_infer' ]]; then
+elif [[ ${MODE} = 'whole_train_whole_infer' ]]; then
 
     # Currently, 'whole_train_whole_infer' mode is not supported.
     :

--- a/contrib/PanopticSeg/test_tipc/test_train_inference_python.sh
+++ b/contrib/PanopticSeg/test_tipc/test_train_inference_python.sh
@@ -192,7 +192,7 @@ if [ ${MODE} = 'whole_infer' ]; then
     else
         env="export CUDA_VISIBLE_DEVICES=${GPUID}"
     fi
-    if [ ${infer_model_dir_list} == 'null' ]; then
+    if [ ${infer_model_dir_list} = 'null' ]; then
         echo -e "\033[33m No inference model is specified! \033[0m"
         exit 1
     fi
@@ -315,7 +315,7 @@ else
                 run_command "${cmd}" "${log_path}"
                 status_check $? "${cmd}" "${status_log}" "${model_name}"
 
-                if [[ "${cmd}" == *'paddle.distributed.launch'* ]]; then
+                if [[ "${cmd}" = *'paddle.distributed.launch'* ]]; then
                     cat log/workerlog.0 >> ${log_path} 
                 fi
 

--- a/deploy/slim/prune/prune.py
+++ b/deploy/slim/prune/prune.py
@@ -77,6 +77,8 @@ def parse_args():
         help='Num workers for data loader',
         type=int,
         default=0)
+    parser.add_argument(
+        '--opts', help='Update the key-value pairs of all options.', nargs='+')
 
     return parser.parse_args()
 
@@ -128,7 +130,8 @@ def main(args):
         args.cfg,
         iters=args.retraining_iters,
         batch_size=args.batch_size,
-        learning_rate=args.learning_rate)
+        learning_rate=args.learning_rate,
+        opts=args.opts)
     builder = SegBuilder(cfg)
 
     train_dataset = builder.train_dataset

--- a/deploy/slim/quant/ptq.py
+++ b/deploy/slim/quant/ptq.py
@@ -48,6 +48,8 @@ def parse_args():
         help='Number of pictures per batch',
         type=int,
         default=1)
+    parser.add_argument(
+        '--opts', help='Update the key-value pairs of all options.', nargs='+')
 
     return parser.parse_args()
 
@@ -65,7 +67,7 @@ def main(args):
     fp32_model_dir = args.model_dir
     quant_output_dir = 'quant_model'
 
-    cfg = Config(args.cfg)
+    cfg = Config(args.cfg, opts=args.opts)
     builder = SegBuilder(cfg)
 
     val_dataset = builder.val_dataset

--- a/deploy/slim/quant/qat_train.py
+++ b/deploy/slim/quant/qat_train.py
@@ -116,6 +116,8 @@ def parse_args():
         default='gpu',
         choices=['cpu', 'gpu'],
         type=str)
+    parser.add_argument(
+        '--opts', help='Update the key-value pairs of all options.', nargs='+')
 
     return parser.parse_args()
 
@@ -143,7 +145,8 @@ def main(args):
         args.cfg,
         learning_rate=args.learning_rate,
         iters=args.iters,
-        batch_size=args.batch_size)
+        batch_size=args.batch_size,
+        opts=args.opts)
     builder = SegBuilder(cfg)
 
     utils.show_env_info()

--- a/deploy/slim/quant/qat_val.py
+++ b/deploy/slim/quant/qat_val.py
@@ -120,6 +120,8 @@ def parse_args():
         default='gpu',
         choices=['cpu', 'gpu', 'xpu', 'npu'],
         type=str)
+    parser.add_argument(
+        '--opts', help='Update the key-value pairs of all options.', nargs='+')
 
     return parser.parse_args()
 
@@ -127,7 +129,7 @@ def parse_args():
 def main(args):
     if not args.cfg:
         raise RuntimeError('No configuration file specified.')
-    cfg = Config(args.cfg)
+    cfg = Config(args.cfg, opts=args.opts)
     builder = SegBuilder(cfg)
 
     utils.show_env_info()

--- a/test_tipc/benchmark_train.sh
+++ b/test_tipc/benchmark_train.sh
@@ -32,7 +32,7 @@ function func_sed_params(){
     value=${array[1]}
     # [Bobholamovic] This if block results in --batch_size=benchmark in the second 
     # test_train_inference_python.sh call, so I comment it out.
-    # if [[ $value =~ 'benchmark_train' ]];then
+    # if [[ $value =~ 'benchmark_train' ]]; then
     #     IFS='='
     #     _val=(${value})
     #     param_value="${_val[0]}=${param_value}"
@@ -140,14 +140,14 @@ for params in ${extra_args[*]}; do
 done
 
 # if params
-if  [ ! -n "$PARAMS" ] ;then
+if  [ ! -n "$PARAMS" ] ; then
     # PARAMS input is not a word.
     IFS="|"
     batch_size_list=(${batch_size})
     fp_items_list=(${fp_items})
     device_num_list=(N1C1 N1C8)
     run_mode="DP"
-elif [[ ${PARAMS} = "dynamicTostatic" ]] ;then
+elif [[ ${PARAMS} = "dynamicTostatic" ]] ; then
     IFS="|"
     model_type=$PARAMS
     batch_size_list=(${batch_size})
@@ -167,7 +167,7 @@ else
     device_num=${params_list[4]}
     IFS=";"
 
-    if [ ${precision} = "null" ];then
+    if [ ${precision} = "null" ]; then
         precision="fp32"
     fi
 
@@ -179,7 +179,7 @@ fi
 # for log name
 to_static=""
 # parse "to_static" options and modify trainer into "to_static_trainer"
-if [[ ${model_type} = "dynamicTostatic" ]];then
+if [[ ${model_type} = "dynamicTostatic" ]]; then
     to_static="d2sT_"
     sed -i 's/trainer:norm_train/trainer:to_static_train/g' $FILENAME
 fi
@@ -194,7 +194,7 @@ for batch_size in ${batch_size_list[*]}; do
             func_sed_params "$FILENAME" "${line_epoch}" "$MODE=$epoch"
             gpu_id=$(set_gpu_id $device_num)
 
-            if [ ${#gpu_id} -le 1 ];then
+            if [ ${#gpu_id} -le 1 ]; then
                 log_path="$SAVE_LOG/profiling_log"
                 mkdir -p $log_path
                 log_name="${repo_name}_${model_name}_bs${batch_size}_${precision}_${run_mode}_${device_num}_${to_static}profiling"

--- a/test_tipc/common_func.sh
+++ b/test_tipc/common_func.sh
@@ -1,43 +1,43 @@
 #!/bin/bash
 
 function func_parser_key(){
-    strs=$1
-    IFS=":"
-    array=(${strs})
-    tmp=${array[0]}
+    local strs=$1
+    local IFS=":"
+    local array=(${strs})
+    local tmp=${array[0]}
     echo ${tmp}
 }
 
 function func_parser_value(){
-    strs=$1
-    IFS=":"
-    array=(${strs})
-    tmp=${array[1]}
+    local strs=$1
+    local IFS=":"
+    local array=(${strs})
+    local tmp=${array[1]}
     echo ${tmp}
 }
 
 function func_parser_key_cpp(){
-    strs=$1
-    IFS=" "
-    array=(${strs})
-    tmp=${array[0]}
+    local strs=$1
+    local IFS=" "
+    local array=(${strs})
+    local tmp=${array[0]}
     echo ${tmp}
 }
 
 function func_parser_value_cpp(){
-    strs=$1
-    IFS=" "
-    array=(${strs})
-    tmp=${array[1]}
+    local strs=$1
+    local IFS=" "
+    local array=(${strs})
+    local tmp=${array[1]}
     echo ${tmp}
 }
 
 function func_set_params(){
-    key=$1
-    value=$2
-    if [ ${key}x = "null"x ];then
+    local key=$1
+    local value=$2
+    if [ ${key}x = "null"x ]; then
         echo " "
-    elif [[ ${value} = "null" ]] || [[ ${value} = " " ]] || [ ${#value} -le 0 ];then
+    elif [[ ${value} = "null" ]] || [[ ${value} = " " ]] || [ ${#value} -le 0 ]; then
         echo " "
     else
         echo "${key}=${value}"
@@ -45,25 +45,25 @@ function func_set_params(){
 }
 
 function func_parser_params(){
-    strs=$1
-    IFS=":"
-    array=(${strs})
-    key=${array[0]}
-    tmp=${array[1]}
-    IFS="|"
-    res=""
+    local strs=$1
+    local IFS=":"
+    local array=(${strs})
+    local key=${array[0]}
+    local tmp=${array[1]}
+    local IFS="|"
+    local res=""
     for _params in ${tmp[*]}; do
-        IFS="="
-        array=(${_params})
-        mode=${array[0]}
-        value=${array[1]}
+        local IFS="="
+        local array=(${_params})
+        local mode=${array[0]}
+        local value=${array[1]}
         if [[ ${mode} = ${MODE} ]]; then
-            IFS="|"
+            local IFS="|"
             #echo (funcsetparams"{mode}" "${value}")
             echo $value
             break
         fi
-        IFS="|"
+        local IFS="|"
     done
     echo ${res}
 }
@@ -85,7 +85,7 @@ function contains() {
     local n=$#
     local value=${!n}
     for ((i=1;i < $#;i++)) {
-        if [ "${!i}" == "${value}" ]; then
+        if [ "${!i}" = "${value}" ]; then
             echo "y"
             return 0
         fi

--- a/test_tipc/prepare.sh
+++ b/test_tipc/prepare.sh
@@ -30,41 +30,42 @@ model_path=test_tipc/output/${model_name}/
 pip install -r requirements.txt
 pip install -r test_tipc/requirements.txt
 # Install current version of PaddleSeg
-pip install -e .
+pip install .
+
 
 if [ ${MODE} = "serving_infer" ]; then
     inference_models=test_tipc/inferences/${model_name}/
     mkdir -p $inference_models
     cd $inference_models && rm -rf * && cd -
 
-    if [ ${model_name} == "stdc_stdc1" ];then
+    if [ ${model_name} = "stdc_stdc1" ]; then
         wget -P $inference_models https://paddleseg.bj.bcebos.com/dygraph/demo/stdc1seg_infer_model.tar.gz --no-check-certificate
         tar xf $inference_models/stdc1seg_infer_model.tar.gz -C $inference_models
-    elif [ ${model_name} == "pp_liteseg_stdc1" ];then
+    elif [ ${model_name} = "pp_liteseg_stdc1" ]; then
         wget -P $inference_models https://paddleseg.bj.bcebos.com/dygraph/demo/pp_liteseg_infer_model.tar.gz --no-check-certificate
         tar xf $inference_models/pp_liteseg_infer_model.tar.gz  -C $inference_models
-    elif [ ${model_name} == "pp_liteseg_stdc2" ];then
+    elif [ ${model_name} = "pp_liteseg_stdc2" ]; then
         wget -P $inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models/pp_liteseg_stdc2_cityscapes_1024x512_scale1.0_160k.zip --no-check-certificate
         unzip $inference_models/pp_liteseg_stdc2_cityscapes_1024x512_scale1.0_160k.zip -d $inference_models/
-    elif [ ${model_name} == "pp_humanseg_lite" ];then
+    elif [ ${model_name} = "pp_humanseg_lite" ]; then
         wget -P $inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models/pp_humanseg_lite_export_398x224.zip --no-check-certificate
         unzip $inference_models/pp_humanseg_lite_export_398x224.zip -d $inference_models/
-    elif [ ${model_name} == "pp_humanseg_mobile" ];then
+    elif [ ${model_name} = "pp_humanseg_mobile" ]; then
         wget -P $inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models/pp_humanseg_mobile_export_192x192.zip --no-check-certificate
         unzip $inference_models/pp_humanseg_mobile_export_192x192.zip -d $inference_models/
-    elif [ ${model_name} == "pp_humanseg_server" ];then
+    elif [ ${model_name} = "pp_humanseg_server" ]; then
         wget -P $inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models/pp_humanseg_server_export_512x512.zip --no-check-certificate
         unzip $inference_models/pp_humanseg_server_export_512x512.zip -d $inference_models/
-    elif [ ${model_name} == "fcn_hrnetw18" ];then
+    elif [ ${model_name} = "fcn_hrnetw18" ]; then
         wget -P $inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models/fcn_hrnetw18_cityscapes_1024x512_80k.zip --no-check-certificate
         unzip $inference_models/fcn_hrnetw18_cityscapes_1024x512_80k.zip -d $inference_models/
-    elif [ ${model_name} == "ocrnet_hrnetw48" ];then
+    elif [ ${model_name} = "ocrnet_hrnetw48" ]; then
         wget -P $inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models/ocrnet_hrnetw48_cityscapes_1024x512_160k.zip --no-check-certificate
         unzip $inference_models/ocrnet_hrnetw48_cityscapes_1024x512_160k.zip -d $inference_models/
-    elif [ ${model_name} == "ocrnet_hrnetw18" ];then
+    elif [ ${model_name} = "ocrnet_hrnetw18" ]; then
         wget -P $inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models/ocrnet_hrnetw18_cityscapes_1024x512_160k.zip --no-check-certificate
         unzip $inference_models/ocrnet_hrnetw18_cityscapes_1024x512_160k.zip -d $inference_models/
-    elif [ ${model_name} == "ppmatting" ];then
+    elif [ ${model_name} = "ppmatting" ]; then
         wget -P $inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models/modnet-mobilenetv2.zip --no-check-certificate
         unzip $inference_models/modnet-mobilenetv2.zip -d $inference_models/
     fi
@@ -72,57 +73,57 @@ fi
 
 # download pretrained model
 if [ ${MODE} = "whole_infer" ] || [ ${MODE} = "klquant_whole_infer" ]; then
-    if [ ${model_name} == "fcn_hrnetw18_small" ];then
+    if [ ${model_name} = "fcn_hrnetw18_small" ]; then
         wget -nc -P $model_path https://paddleseg.bj.bcebos.com/dygraph/humanseg/train/fcn_hrnetw18_small_v1_humanseg_192x192.zip --no-check-certificate
         cd $model_path && unzip fcn_hrnetw18_small_v1_humanseg_192x192.zip  &&  cd -
-    elif [ ${model_name} == "pphumanseg_lite" ];then
+    elif [ ${model_name} = "pphumanseg_lite" ]; then
         wget -nc -P $model_path https://paddleseg.bj.bcebos.com/dygraph/humanseg/train/pphumanseg_lite_generic_192x192.zip --no-check-certificate
         cd $model_path && unzip pphumanseg_lite_generic_192x192.zip  &&  cd -
-    elif [ ${model_name} == "deeplabv3p_resnet50" ];then
+    elif [ ${model_name} = "deeplabv3p_resnet50" ]; then
         wget -nc -P $model_path https://paddleseg.bj.bcebos.com/dygraph/humanseg/train/deeplabv3p_resnet50_os8_humanseg_512x512_100k.zip --no-check-certificate
         cd $model_path && unzip deeplabv3p_resnet50_os8_humanseg_512x512_100k.zip && cd -
-    elif [ ${model_name} == "bisenetv2" ];then
+    elif [ ${model_name} = "bisenetv2" ]; then
         wget -nc -P $model_path https://bj.bcebos.com/paddleseg/dygraph/cityscapes/bisenet_cityscapes_1024x1024_160k/model.pdparams --no-check-certificate
-    elif [ ${model_name} == "ocrnet_hrnetw18" ];then
+    elif [ ${model_name} = "ocrnet_hrnetw18" ]; then
         wget -nc -P $model_path https://bj.bcebos.com/paddleseg/dygraph/cityscapes/ocrnet_hrnetw18_cityscapes_1024x512_160k/model.pdparams --no-check-certificate
-    elif [ ${model_name} == "segformer_b0" ];then
+    elif [ ${model_name} = "segformer_b0" ]; then
         wget -nc -P $model_path https://bj.bcebos.com/paddleseg/dygraph/cityscapes/segformer_b0_cityscapes_1024x1024_160k/model.pdparams --no-check-certificate
-    elif [ ${model_name} == "stdc_stdc1" ];then
+    elif [ ${model_name} = "stdc_stdc1" ]; then
         wget -nc -P $model_path https://bj.bcebos.com/paddleseg/dygraph/cityscapes/stdc1_seg_cityscapes_1024x512_80k/model.pdparams --no-check-certificate
-    elif [ ${model_name} == "ppmatting" ];then
+    elif [ ${model_name} = "ppmatting" ]; then
         wget -nc -P $model_path https://paddleseg.bj.bcebos.com/matting/models/modnet-mobilenetv2.pdparams --no-check-certificate
-    elif [ ${model_name} == "pp_liteseg_stdc1" ];then
+    elif [ ${model_name} = "pp_liteseg_stdc1" ]; then
         wget -nc -P $model_path https://paddleseg.bj.bcebos.com/dygraph/cityscapes/pp_liteseg_stdc1_cityscapes_1024x512_scale1.0_160k/model.pdparams --no-check-certificate
-    elif [ ${model_name} == "pp_liteseg_stdc2" ];then
+    elif [ ${model_name} = "pp_liteseg_stdc2" ]; then
         wget -nc -P $model_path https://paddleseg.bj.bcebos.com/dygraph/cityscapes/pp_liteseg_stdc2_cityscapes_1024x512_scale1.0_160k/model.pdparams --no-check-certificate
-    elif [ ${model_name} == "ddrnet" ];then
+    elif [ ${model_name} = "ddrnet" ]; then
         wget -nc -P $model_path https://bj.bcebos.com/paddleseg/dygraph/cityscapes/ddrnet23_cityscapes_1024x1024_120k/model.pdparams --no-check-certificate
 
-    elif [ ${model_name} == "pp_liteseg_stdc1_KL" ];then
+    elif [ ${model_name} = "pp_liteseg_stdc1_KL" ]; then
         wget -P $model_path https://paddleseg.bj.bcebos.com/dygraph/demo/pp_liteseg_infer_model.tar.gz --no-check-certificate
         tar xf ${model_path}/pp_liteseg_infer_model.tar.gz  -C $model_path
-    elif [ ${model_name} == "pp_liteseg_stdc2_KL" ];then
+    elif [ ${model_name} = "pp_liteseg_stdc2_KL" ]; then
         wget -P ${model_path} https://paddleseg.bj.bcebos.com/tipc/infer_models/pp_liteseg_stdc2_cityscapes_1024x512_scale1.0_160k.zip --no-check-certificate
         unzip -o ${model_path}/pp_liteseg_stdc2_cityscapes_1024x512_scale1.0_160k.zip -d ${model_path}/
-    elif [ ${model_name} == "pp_humanseg_lite_KL" ];then
+    elif [ ${model_name} = "pp_humanseg_lite_KL" ]; then
         wget -P ${model_path} https://paddleseg.bj.bcebos.com/tipc/infer_models/pp_humanseg_lite_export_398x224.zip --no-check-certificate
         unzip -o ${model_path}/pp_humanseg_lite_export_398x224 -d ${model_path}/
-    elif [ ${model_name} == "fcn_hrnetw18_small_KL" ];then
+    elif [ ${model_name} = "fcn_hrnetw18_small_KL" ]; then
         wget -P ${model_path} https://paddleseg.bj.bcebos.com/tipc/infer_models/pp_humanseg_mobile_export_192x192.zip --no-check-certificate
         unzip -o ${model_path}/pp_humanseg_mobile_export_192x192.zip -d ${model_path}/
-    elif [ ${model_name} == "deeplabv3p_resnet50_KL" ];then
+    elif [ ${model_name} = "deeplabv3p_resnet50_KL" ]; then
         wget -P ${model_path} https://paddleseg.bj.bcebos.com/tipc/infer_models/pp_humanseg_server_export_512x512.zip --no-check-certificate
         unzip -o ${model_path}/pp_humanseg_server_export_512x512.zip -d ${model_path}/
-    elif [ ${model_name} == "fcn_hrnetw18_KL" ];then
+    elif [ ${model_name} = "fcn_hrnetw18_KL" ]; then
         wget -P ${model_path} https://paddleseg.bj.bcebos.com/tipc/infer_models/fcn_hrnetw18_cityscapes_1024x512_80k.zip --no-check-certificate
         unzip -o ${model_path}/fcn_hrnetw18_cityscapes_1024x512_80k.zip -d ${model_path}/
-    elif [ ${model_name} == "ocrnet_hrnetw48_KL" ];then
+    elif [ ${model_name} = "ocrnet_hrnetw48_KL" ]; then
         wget -P ${model_path} https://paddleseg.bj.bcebos.com/tipc/infer_models/ocrnet_hrnetw48_cityscapes_1024x512_160k.zip --no-check-certificate
         unzip -o ${model_path}/ocrnet_hrnetw48_cityscapes_1024x512_160k.zip -d ${model_path}/
-    elif [ ${model_name} == "ocrnet_hrnetw18_KL" ];then
+    elif [ ${model_name} = "ocrnet_hrnetw18_KL" ]; then
         wget -P ${model_path} https://paddleseg.bj.bcebos.com/tipc/infer_models/ocrnet_hrnetw18_cityscapes_1024x512_160k.zip --no-check-certificate
         unzip -o ${model_path}/ocrnet_hrnetw18_cityscapes_1024x512_160k.zip -d ${model_path}/
-    elif [ ${model_name} == "segformer_b0_KL" ];then
+    elif [ ${model_name} = "segformer_b0_KL" ]; then
         wget -nc -P $model_path https://paddleseg.bj.bcebos.com/tipc/infer_models/segformer_b0_cityscapes_1024x1024_160k.zip --no-check-certificate
         unzip -o ${model_path}/segformer_b0_cityscapes_1024x1024_160k.zip -d ${model_path}/
     fi
@@ -130,17 +131,17 @@ fi
 
 # download data
 mkdir -p ./test_tipc/data
-if [ ${MODE} = "benchmark_train" ];then
+if [ ${MODE} = "benchmark_train" ]; then
     if [ ${model_name} = 'fcn_hrnetw18_small' ] \
         || [ ${model_name} = 'pphumanseg_lite' ] \
         || [ ${model_name} = 'deeplabv3p_resnet50' ] \
         || [ ${model_name} = 'pp_humanseg_lite_KL' ] \
         || [ ${model_name} = 'fcn_hrnetw18_small_KL' ] \
-        || [ ${model_name} = 'deeplabv3p_resnet50_KL' ];then
+        || [ ${model_name} = 'deeplabv3p_resnet50_KL' ]; then
         rm -rf ./test_tipc/data/mini_supervisely
         wget -nc -P ./test_tipc/data/ https://paddleseg.bj.bcebos.com/humanseg/data/mini_supervisely.zip --no-check-certificate
         cd ./test_tipc/data/ && unzip mini_supervisely.zip && cd -
-    elif [ ${model_name} = 'ppmatting' ];then
+    elif [ ${model_name} = 'ppmatting' ]; then
         rm -rf ./test_tipc/data/PPM-100
         wget -nc -P ./test_tipc/data/ https://paddleseg.bj.bcebos.com/matting/datasets/PPM-100.zip --no-check-certificate
         cd ./test_tipc/data/ && unzip PPM-100.zip && cd -
@@ -155,20 +156,20 @@ if [ ${MODE} = "benchmark_train" ];then
         tar -zxf ./test_tipc/data/cityscapes_300imgs.tar.gz -C ./test_tipc/data/
         mv ./test_tipc/data/cityscapes_300imgs ./test_tipc/data/cityscapes
     fi
-elif [ ${MODE} == "serving_infer" ];then
+elif [ ${MODE} = "serving_infer" ]; then
     wget -nc -P ./test_tipc/data https://paddleseg.bj.bcebos.com/dygraph/demo/cityscapes_small.png --no-check-certificate
-elif [ ${MODE} = "lite_train_lite_infer" ] || [ ${MODE} = "lite_train_whole_infer" ] || [ ${MODE} = "whole_train_whole_infer" ] || [ ${MODE} = "whole_infer" ];then
+elif [ ${MODE} = "lite_train_lite_infer" ] || [ ${MODE} = "lite_train_whole_infer" ] || [ ${MODE} = "whole_train_whole_infer" ] || [ ${MODE} = "whole_infer" ]; then
 
-    if [ ${model_name} == "fcn_hrnetw18_small" ] || [ ${model_name} == "pphumanseg_lite" ] || [ ${model_name} == "deeplabv3p_resnet50" ] || [ ${model_name} == "pp_humanseg_lite_KL" ] || [ ${model_name} == "fcn_hrnetw18_small_KL" ] || [ ${model_name} == "deeplabv3p_resnet50_KL" ];then
+    if [ ${model_name} = "fcn_hrnetw18_small" ] || [ ${model_name} = "pphumanseg_lite" ] || [ ${model_name} = "deeplabv3p_resnet50" ] || [ ${model_name} = "pp_humanseg_lite_KL" ] || [ ${model_name} = "fcn_hrnetw18_small_KL" ] || [ ${model_name} = "deeplabv3p_resnet50_KL" ]; then
         rm -rf ./test_tipc/data/mini_supervisely
         wget -nc -P ./test_tipc/data/ https://paddleseg.bj.bcebos.com/humanseg/data/mini_supervisely.zip --no-check-certificate
         cd ./test_tipc/data/ && unzip mini_supervisely.zip && cd -
-    elif [ ${model_name} == "ppmatting" ];then
+    elif [ ${model_name} = "ppmatting" ]; then
         rm -rf ./test_tipc/data/PPM-100
         wget -nc -P ./test_tipc/data/ https://paddleseg.bj.bcebos.com/matting/datasets/PPM-100.zip --no-check-certificate
         cd ./test_tipc/data/ && unzip PPM-100.zip && cd -
     else
-        if [ ${MODE} = "whole_train_whole_infer" ];then
+        if [ ${MODE} = "whole_train_whole_infer" ]; then
             rm -rf ./test_tipc/data/cityscapes
             wget -nc -P ./test_tipc/data/ https://paddleseg.bj.bcebos.com/dataset/cityscapes.tar --no-check-certificate
             cd ./test_tipc/data/ && tar -xf cityscapes.tar && cd -
@@ -181,37 +182,37 @@ elif [ ${MODE} = "lite_train_lite_infer" ] || [ ${MODE} = "lite_train_whole_infe
 fi
 
 # prepare env
-if [ ${MODE} = "cpp_infer" ];then
+if [ ${MODE} = "cpp_infer" ]; then
     # wget model
     cd test_tipc/cpp/ && mkdir -p inference_models
-    if [ ${model_name} == "stdc_stdc1" ];then
+    if [ ${model_name} = "stdc_stdc1" ]; then
         wget -P inference_models https://paddleseg.bj.bcebos.com/dygraph/demo/stdc1seg_infer_model.tar.gz --no-check-certificate
         tar xf inference_models/stdc1seg_infer_model.tar.gz -C inference_models
-    elif [ ${model_name} == "pp_liteseg_stdc1" ];then
+    elif [ ${model_name} = "pp_liteseg_stdc1" ]; then
         wget -P inference_models https://paddleseg.bj.bcebos.com/dygraph/demo/pp_liteseg_infer_model.tar.gz --no-check-certificate
         tar xf inference_models/pp_liteseg_infer_model.tar.gz  -C inference_models
-    elif [ ${model_name} == "pp_liteseg_stdc2" ];then
+    elif [ ${model_name} = "pp_liteseg_stdc2" ]; then
         wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models_i32/pp_liteseg_stdc2_cityscapes_1024x512_scale1.0_160k.zip --no-check-certificate
         unzip inference_models/pp_liteseg_stdc2_cityscapes_1024x512_scale1.0_160k.zip -d inference_models/
-    elif [ ${model_name} == "pphumanseg_lite" ];then
+    elif [ ${model_name} = "pphumanseg_lite" ]; then
         wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models_i32/pp_humanseg_lite_export_398x224.zip --no-check-certificate
         unzip inference_models/pp_humanseg_lite_export_398x224 -d inference_models/
-    elif [ ${model_name} == "fcn_hrnetw18_small" ];then
+    elif [ ${model_name} = "fcn_hrnetw18_small" ]; then
         wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models_i32/pp_humanseg_mobile_export_192x192.zip --no-check-certificate
         unzip inference_models/pp_humanseg_mobile_export_192x192.zip -d inference_models/
-    elif [ ${model_name} == "deeplabv3p_resnet50" ];then
+    elif [ ${model_name} = "deeplabv3p_resnet50" ]; then
         wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models_i32/pp_humanseg_server_export_512x512.zip --no-check-certificate
         unzip inference_models/pp_humanseg_server_export_512x512.zip -d inference_models/
-    elif [ ${model_name} == "fcn_hrnetw18" ];then
+    elif [ ${model_name} = "fcn_hrnetw18" ]; then
         wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models_i32/fcn_hrnetw18_cityscapes_1024x512_80k.zip --no-check-certificate
         unzip inference_models/fcn_hrnetw18_cityscapes_1024x512_80k.zip -d inference_models/
-    elif [ ${model_name} == "ocrnet_hrnetw48" ];then
+    elif [ ${model_name} = "ocrnet_hrnetw48" ]; then
         wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models_i32/ocrnet_hrnetw48_cityscapes_1024x512_160k.zip --no-check-certificate
         unzip inference_models/ocrnet_hrnetw48_cityscapes_1024x512_160k.zip -d inference_models/
-    elif [ ${model_name} == "ocrnet_hrnetw18" ];then
+    elif [ ${model_name} = "ocrnet_hrnetw18" ]; then
         wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models_i32/ocrnet_hrnetw18_cityscapes_1024x512_160k.zip --no-check-certificate
         unzip inference_models/ocrnet_hrnetw18_cityscapes_1024x512_160k.zip -d inference_models/
-    elif [ ${model_name} == "segformer_b0" ];then
+    elif [ ${model_name} = "segformer_b0" ]; then
         wget -P inference_models https://paddleseg.bj.bcebos.com/tipc/infer_models_i32/segformer_b0_cityscapes_1024x1024_160k.zip --no-check-certificate
         unzip inference_models/segformer_b0_cityscapes_1024x1024_160k.zip -d inference_models/
     fi
@@ -260,7 +261,7 @@ if [ ${MODE} = "cpp_infer" ];then
     # build cpp
     bash build.sh
 
-elif [ ${MODE} = "paddle2onnx_infer" ];then
+elif [ ${MODE} = "paddle2onnx_infer" ]; then
     # install paddle2onnx
     python_name_list=$(func_parser_value "${lines[2]}")
     IFS='|'
@@ -270,31 +271,31 @@ elif [ ${MODE} = "paddle2onnx_infer" ];then
     ${python_name} -m pip install onnxruntime==1.9.0
     # get model
     rm -rf ./test_tipc/infer_models
-    if [[ ${model_name} == "pp_liteseg_stdc1" ]];then
+    if [[ ${model_name} = "pp_liteseg_stdc1" ]]; then
         wget -nc -P  ./test_tipc/infer_models https://paddleseg.bj.bcebos.com/tipc/infer_models/pp_liteseg_stdc1_fix_shape.zip  --no-check-certificate
         cd ./test_tipc/infer_models && unzip pp_liteseg_stdc1_fix_shape.zip && cd -
-    elif [[ ${model_name} == "pp_liteseg_stdc2" ]];then
+    elif [[ ${model_name} = "pp_liteseg_stdc2" ]]; then
         wget -nc -P  ./test_tipc/infer_models https://paddleseg.bj.bcebos.com/tipc/infer_models/pp_liteseg_stdc2_fix_shape.zip --no-check-certificate
         cd ./test_tipc/infer_models && unzip pp_liteseg_stdc2_fix_shape.zip && cd -
-    elif [ ${model_name} == "pp_humanseg_lite" ];then
+    elif [ ${model_name} = "pp_humanseg_lite" ]; then
         wget -P ./test_tipc/infer_models https://paddleseg.bj.bcebos.com/tipc/infer_models/pp_humanseg_lite_export_398x224.zip --no-check-certificate
         cd ./test_tipc/infer_models && unzip pp_humanseg_lite_export_398x224.zip && cd -
-    elif [ ${model_name} == "fcn_hrnetw18_small" ];then
+    elif [ ${model_name} = "fcn_hrnetw18_small" ]; then
         wget -P ./test_tipc/infer_models https://paddleseg.bj.bcebos.com/tipc/infer_models/pp_humanseg_mobile_export_192x192.zip --no-check-certificate
         cd ./test_tipc/infer_models && unzip pp_humanseg_mobile_export_192x192.zip && cd -
-    elif [ ${model_name} == "deeplabv3p_resnet50" ];then
+    elif [ ${model_name} = "deeplabv3p_resnet50" ]; then
         wget -P ./test_tipc/infer_models https://paddleseg.bj.bcebos.com/tipc/infer_models/pp_humanseg_server_export_512x512.zip --no-check-certificate
         cd ./test_tipc/infer_models && unzip pp_humanseg_server_export_512x512.zip && cd -
-    elif [ ${model_name} == "ppmatting" ];then
+    elif [ ${model_name} = "ppmatting" ]; then
         wget -P ./test_tipc/infer_models https://paddleseg.bj.bcebos.com/tipc/infer_models/modnet-mobilenetv2.zip --no-check-certificate
         cd ./test_tipc/infer_models && unzip modnet-mobilenetv2.zip && cd -
-    elif [ ${model_name} == "fcn_hrnetw18" ];then
+    elif [ ${model_name} = "fcn_hrnetw18" ]; then
         wget -P ./test_tipc/infer_models https://paddleseg.bj.bcebos.com/tipc/infer_models/fcn_hrnetw18_cityscapes_1024x512_80k.zip --no-check-certificate
         cd ./test_tipc/infer_models && unzip fcn_hrnetw18_cityscapes_1024x512_80k.zip && cd -
-    elif [ ${model_name} == "ocrnet_hrnetw48" ];then
+    elif [ ${model_name} = "ocrnet_hrnetw48" ]; then
         wget -P ./test_tipc/infer_models https://paddleseg.bj.bcebos.com/tipc/infer_models/ocrnet_hrnetw48_cityscapes_1024x512_160k.zip --no-check-certificate
         cd ./test_tipc/infer_models && unzip ocrnet_hrnetw48_cityscapes_1024x512_160k.zip && cd -
-    elif [ ${model_name} == "ocrnet_hrnetw18" ];then
+    elif [ ${model_name} = "ocrnet_hrnetw18" ]; then
         wget -P ./test_tipc/infer_models https://paddleseg.bj.bcebos.com/tipc/infer_models/ocrnet_hrnetw18_cityscapes_1024x512_160k.zip --no-check-certificate
         cd ./test_tipc/infer_models && unzip ocrnet_hrnetw18_cityscapes_1024x512_160k.zip && cd -
     fi

--- a/test_tipc/prepare_js.sh
+++ b/test_tipc/prepare_js.sh
@@ -29,7 +29,7 @@ fi
 # MODE be 'js_infer'
 MODE=$1
 # js_infer MODE , load model file and convert model to js_infer
-if [ ${MODE} != "js_infer" ];then
+if [ ${MODE} != "js_infer" ]; then
     echo "Please change mode to 'js_infer'"
     exit
 fi
@@ -39,6 +39,12 @@ fi
 saved_model_name=pphumanseg_lite
 # model_path
 model_path=test_tipc/web/models/
+
+# Install dependencies
+pip install -r requirements.txt
+pip install -r test_tipc/requirements.txt
+# Install current version of PaddleSeg
+pip install .
 
 rm -rf $model_path
 echo ${model_path}${saved_model_name}
@@ -73,7 +79,7 @@ npm install @paddlejs-models/humanseg@latest
 echo -e "\033[32m The latest humanseg sdk installed completely.!~ \033[0m"
 
 # install dependencies
-if [ `npm list --dept 0 | grep puppeteer | wc -l` -ne 0 ] && [ `npm list --dept 0 | grep jest | wc -l` -ne 0 ];then
+if [ `npm list --dept 0 | grep puppeteer | wc -l` -ne 0 ] && [ `npm list --dept 0 | grep jest | wc -l` -ne 0 ]; then
     echo -e "\033[32m Dependencies have installed \033[0m"
 else
     echo -e "\033[33m Installing dependencies ... \033[0m"

--- a/test_tipc/test_serving_infer_cpp.sh
+++ b/test_tipc/test_serving_infer_cpp.sh
@@ -110,7 +110,7 @@ function func_serving(){
 
 # set cuda device
 GPUID=$3
-if [ ${#GPUID} -le 0 ];then
+if [ ${#GPUID} -le 0 ]; then
     env=" "
 else
     env="export CUDA_VISIBLE_DEVICES=${GPUID}"

--- a/test_tipc/test_serving_infer_python.sh
+++ b/test_tipc/test_serving_infer_python.sh
@@ -101,7 +101,7 @@ function func_serving(){
 
 # set cuda device
 GPUID=$3
-if [ ${#GPUID} -le 0 ];then
+if [ ${#GPUID} -le 0 ]; then
     env=" "
 else
     env="export CUDA_VISIBLE_DEVICES=${GPUID}"

--- a/test_tipc/test_train_inference_python.sh
+++ b/test_tipc/test_train_inference_python.sh
@@ -113,8 +113,8 @@ for params in ${extra_args[*]}; do
     fi
 done
 
-if [ "${MODE}" = 'benchmark_train' ];then
-    if [ "${autocast_key}" = 'Global.auto_cast' ];then
+if [ "${MODE}" = 'benchmark_train' ]; then
+    if [ "${autocast_key}" = 'Global.auto_cast' ]; then
         echo 'Replcace ${autocast_key}'"('${autocast_key}') with '--precision'"
         autocast_key="--precision"
     fi
@@ -211,7 +211,7 @@ function func_inference(){
 
 if [ ${MODE} = "whole_infer" ] || [ ${MODE} = "klquant_whole_infer" ]; then
     GPUID=$3
-    if [ ${#GPUID} -le 0 ];then
+    if [ ${#GPUID} -le 0 ]; then
         env=" "
     else
         env="export CUDA_VISIBLE_DEVICES=${GPUID}"
@@ -225,7 +225,7 @@ if [ ${MODE} = "whole_infer" ] || [ ${MODE} = "klquant_whole_infer" ]; then
     infer_quant_flag=(${infer_is_quant})
     for infer_model in ${infer_model_dir_list[*]}; do
         # run export
-        if [ ${infer_run_exports[Count]} != "null" ];then
+        if [ ${infer_run_exports[Count]} != "null" ]; then
             save_infer_dir=$(dirname $infer_model)
             set_export_weight=$(func_set_params "${export_weight}" "${infer_model}")
             set_save_infer_key=$(func_set_params "${save_infer_key}" "${save_infer_dir}")
@@ -253,12 +253,12 @@ else
         train_use_gpu=${USE_GPU_KEY[Count]}
         Count=$(($Count + 1))
         ips=""
-        if [ ${gpu} = "-1" ];then
+        if [ ${gpu} = "-1" ]; then
             env=""
-        elif [ ${#gpu} -le 1 ];then
+        elif [ ${#gpu} -le 1 ]; then
             env="export CUDA_VISIBLE_DEVICES=${gpu}"
             eval ${env}
-        elif [ ${#gpu} -le 15 ];then
+        elif [ ${#gpu} -le 15 ]; then
             IFS=","
             array=(${gpu})
             env="export CUDA_VISIBLE_DEVICES=${array[0]}"
@@ -274,7 +274,7 @@ else
         for autocast in ${autocast_list[*]}; do
             if [ ${autocast} = "amp" ]; then
                 set_amp_config="Global.use_amp=True Global.scale_loss=1024.0 Global.use_dynamic_loss_scaling=True"
-            elif [ "${autocast}" = 'fp16' ] && [ "${MODE}" = 'benchmark_train' ];then
+            elif [ "${autocast}" = 'fp16' ] && [ "${MODE}" = 'benchmark_train' ]; then
                 set_amp_config="--amp_level=O2"
             else
                 set_amp_config=" "
@@ -316,7 +316,7 @@ else
                 set_use_gpu=$(func_set_params "${train_use_gpu_key}" "${train_use_gpu}")
                 # if length of ips >= 15, then it is seen as multi-machine
                 # 15 is the min length of ips info for multi-machine: 0.0.0.0,0.0.0.0
-                if [ ${#ips} -le 15 ];then
+                if [ ${#ips} -le 15 ]; then
                     save_log="${LOG_PATH}/${trainer}_gpus_${gpu}_autocast_${autocast}"
                     nodes=1
                 else
@@ -334,23 +334,23 @@ else
                 fi
 
                 set_save_model=$(func_set_params "${save_model_key}" "${save_log}")
-                if [ ${#gpu} -le 2 ];then  # train with cpu or single gpu
+                if [ ${#gpu} -le 2 ]; then  # train with cpu or single gpu
                     cmd="${python} ${run_train} ${set_use_gpu}  ${set_save_model} ${set_epoch} ${set_pretrain} ${set_autocast} ${set_batchsize} ${set_train_params1} ${set_amp_config}"
-                elif [ ${#ips} -le 15 ];then  # train with multi-gpu
+                elif [ ${#ips} -le 15 ]; then  # train with multi-gpu
                     cmd="${python} -m paddle.distributed.launch --devices=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_epoch} ${set_pretrain} ${set_autocast} ${set_batchsize} ${set_train_params1} ${set_amp_config}"
                 else     # train with multi-machine
                     cmd="${python} -m paddle.distributed.launch --ips=${ips} --devices=${gpu} ${run_train} ${set_use_gpu} ${set_save_model} ${set_pretrain} ${set_epoch} ${set_autocast} ${set_batchsize} ${set_train_params1} ${set_amp_config}"
                 fi
                 
-                if [ "${MODE}" = 'benchmark_train' ] && [ -n "${log_iters}" ];then
+                if [ "${MODE}" = 'benchmark_train' ] && [ -n "${log_iters}" ]; then
                     cmd="${cmd} --log_iters ${log_iters}"
                 fi
 
-                if [ "${MODE}" = 'benchmark_train' ] && [ -n "${repeats}" ];then
+                if [ "${MODE}" = 'benchmark_train' ] && [ -n "${repeats}" ]; then
                     cmd="${cmd} --repeats ${repeats}"
                 fi
 
-                if [ -n "${amp_level}" ];then
+                if [ -n "${amp_level}" ]; then
                     cmd="${cmd} --amp_level ${amp_level}"
                 fi
 
@@ -359,7 +359,7 @@ else
                 run_command "${cmd}" "${log_path}"
                 status_check $? "${cmd}" "${status_log}" "${model_name}" "${log_path}"
 
-                if [[ "$cmd" == *'paddle.distributed.launch'* ]]; then
+                if [[ "$cmd" = *'paddle.distributed.launch'* ]]; then
                     cat log/workerlog.0 >> ${log_path} 
                 fi
                 

--- a/tests/benchmark/run_benchmark.sh
+++ b/tests/benchmark/run_benchmark.sh
@@ -51,7 +51,7 @@ function _train(){
     esac
 
     timeout 15m ${train_cmd} > ${log_file} 2>&1
-    if [ $? -ne 0 ];then
+    if [ $? -ne 0 ]; then
         echo -e "${model_name}, FAIL"
         export job_fail_flag=1
     else

--- a/tests/infer/test_infer_benchmark.sh
+++ b/tests/infer/test_infer_benchmark.sh
@@ -22,7 +22,7 @@ mkdir -p ${pretrained_root_path}
 mkdir -p ${save_root_path}
 
 img_path="${save_root_path}/cityscapes_demo.png"
-if [ ! -f ${img_path} ];then
+if [ ! -f ${img_path} ]; then
     wget https://paddleseg.bj.bcebos.com/dygraph/demo/cityscapes_demo.png -O ${img_path}
 fi
 
@@ -37,7 +37,7 @@ do
     model_name=$(basename ${config_path} .yml)
     download_path="${download_root_path}/${model_name}/model.pdparams"
     urlstatus=$(curl -s -m 5 -IL $download_path | grep 200)
-    if [ "$urlstatus" != "" ] && [[ $config_path =~ "cityscapes" ]];then
+    if [ "$urlstatus" != "" ] && [[ $config_path =~ "cityscapes" ]]; then
         configs_path[${#configs_path[@]}]=${config_path}
     fi
 done
@@ -53,7 +53,7 @@ do
 
     download_path=${download_root_path}/${model_name}/model.pdparams
     pretrained_path=${pretrained_root_path}/${model_name}.pdparams
-    if [ ! -f ${pretrained_path} ];then
+    if [ ! -f ${pretrained_path} ]; then
         echo -e "\n Download pretrained weights"
         wget ${download_path} -O ${pretrained_path}
     fi

--- a/tests/infer/test_infer_dataset.sh
+++ b/tests/infer/test_infer_dataset.sh
@@ -40,7 +40,7 @@ do
     model_name=$(basename ${config_path} .yml)
     download_path="${download_root_path}/${model_name}/model.pdparams"
     urlstatus=$(curl -s -m 5 -IL $download_path | grep 200)
-    if [ "$urlstatus" != "" ] && [[ $config_path =~ "cityscapes" ]];then
+    if [ "$urlstatus" != "" ] && [[ $config_path =~ "cityscapes" ]]; then
         configs_path[${#configs_path[@]}]=${config_path}
     fi
 done
@@ -56,7 +56,7 @@ do
 
     download_path=${download_root_path}/${model_name}/model.pdparams
     pretrained_path=${pretrained_root_path}/${model_name}.pdparams
-    if [ ! -f ${pretrained_path} ];then
+    if [ ! -f ${pretrained_path} ]; then
         echo -e "\n Download pretrained weights"
         wget ${download_path} -O ${pretrained_path}
     fi


### PR DESCRIPTION
### PR types
New features

### PR changes
User scripts

### Description

1. 为量化、部署相关脚本（含ptq等）添加`--opts`功能。
2. 在特定条件下可能出现 TIPC 执行完 `prepare.sh` 后仍 PaddleSeg 无法正常安装的问题，该问题使 CI 不稳定，如：
![image](https://user-images.githubusercontent.com/21275753/215239908-5da876fc-368e-4b2e-95c4-50e8b61367eb.png)
排查到此问题出现条件为： docker 环境+root 用户直接安装+以 pip editable 模式本地安装。此时，`egg.link`失效，Python 无法正确将安装的模块添加到路径。具体原因尚未定位。考虑到 editable 模式安装对于 TIPC 并非必要，目前采取策略是在`prepare.sh`安装PaddleSeg时不使用`-e`选项。
3. 将 shell 脚本中使用的 `[ a == b ]` 语法修改为符合 POSIX 标准的 `[ a = b ]`，以使其具备更好的兼容性（部分情况下用户可能使用 sh 而非 bash 执行脚本，而在 Bourne shell 语言的 `test` 语法中 `==` 与 `=` 并不等价）。
4. 为部分 shell 公用函数中的局部变量添加 local 作用域限制，防止命名空间污染。