### PR TITLE
[Bug nranks_download]

### DIFF
--- a/configs/portraitnet/portraitnet_eg1800_224x224_46k.yml
+++ b/configs/portraitnet/portraitnet_eg1800_224x224_46k.yml
@@ -68,5 +68,5 @@ model:
   backbone:
     type: MobileNetV2_x1_0
     pretrained: https://paddleseg.bj.bcebos.com/dygraph/backbone/mobilenetv2_x1_0_ssld.tar.gz
-  add_edge: True
+  add_edge: False
   num_classes: 2

--- a/paddleseg/utils/download.py
+++ b/paddleseg/utils/download.py
@@ -146,21 +146,34 @@ def download_file_and_uncompress(url,
             shutil.rmtree(extraname)
     full_path = os.path.join(extraname,
                              filename) if filename is not None else extraname
+
+    rank_id_curr_node = int(os.environ.get("PADDLE_RANK_IN_NODE", 0))
+
     if not os.path.exists(
             full_path):  # If pretrained model exists, skip download process.
-        if not os.path.exists(savename):
-            if not os.path.exists(savepath):
-                _download_file(url, savepath, print_progress)
+        lock_path = extraname + '.download.lock'
+        with open(lock_path, 'w'):  # touch    
+            os.utime(lock_path, None)
+        if rank_id_curr_node == 0:
+            if not os.path.exists(savename):
+                if not os.path.exists(savepath):
+                    _download_file(url, savepath, print_progress)
 
-            if (not tarfile.is_tarfile(savepath)) and (
-                    not zipfile.is_zipfile(savepath)):
-                if not os.path.exists(extraname):
-                    os.makedirs(extraname)
-                shutil.move(savepath, extraname)
-                return extraname
+                if (not tarfile.is_tarfile(savepath)) and (
+                        not zipfile.is_zipfile(savepath)):
+                    if not os.path.exists(extraname):
+                        os.makedirs(extraname)
 
-            savename = _uncompress_file(savepath, extrapath, delete_file,
-                                        print_progress)
-            savename = os.path.join(extrapath, savename)
-        shutil.move(savename, extraname)
+                else:
+                    savename = _uncompress_file(savepath, extrapath,
+                                                delete_file, print_progress)
+                    savename = os.path.join(extrapath, savename)
+
+            shutil.move(savename, extraname)
+            os.remove(lock_path)
+
+        else:
+            while os.path.exists(lock_path):
+                time.sleep(0.5)
+
     return extraname


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what this PR does -->
bugs in download_file_and_uncompress
Mainly used to solve the problem of downloading and uncompressing data from different ranks to **synchronize** data. Different nodes will download data and uncompress data or weights of pretrained model once. 
