### PR TITLE
[WIP]replace paddle.shape with tensor.shape in to_static mode

### DIFF
--- a/paddleseg/models/backbones/mix_transformer.py
+++ b/paddleseg/models/backbones/mix_transformer.py
@@ -19,6 +19,7 @@ import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
 import paddle.nn.initializer as paddle_init
+from paddle.fluid.dygraph.base import in_declarative_mode
 
 from paddleseg.cvlibs import manager
 from paddleseg.utils import utils
@@ -115,7 +116,7 @@ class Attention(nn.Layer):
                 zeros_(m.bias)
 
     def forward(self, x, H, W):
-        x_shape = paddle.shape(x)
+        x_shape = x.shape if in_declarative_mode() else paddle.shape(x)
         B, N = x_shape[0], x_shape[1]
         C = self.dim
 
@@ -248,7 +249,7 @@ class OverlapPatchEmbed(nn.Layer):
 
     def forward(self, x):
         x = self.proj(x)
-        x_shape = paddle.shape(x)
+        x_shape = x.shape if in_declarative_mode() else paddle.shape(x)
         H, W = x_shape[2], x_shape[3]
         x = x.flatten(2).transpose([0, 2, 1])
         x = self.norm(x)
@@ -430,7 +431,7 @@ class MixVisionTransformer(nn.Layer):
                               num_classes) if num_classes > 0 else nn.Identity()
 
     def forward_features(self, x):
-        B = paddle.shape(x)[0]
+        B = x.shape[0] if in_declarative_mode() else paddle.shape(x)[0]
         outs = []
 
         # stage 1
@@ -482,7 +483,7 @@ class DWConv(nn.Layer):
         self.dwconv = nn.Conv2D(dim, dim, 3, 1, 1, bias_attr=True, groups=dim)
 
     def forward(self, x, H, W):
-        x_shape = paddle.shape(x)
+        x_shape = x.shape if in_declarative_mode() else paddle.shape(x)
         B, N = x_shape[0], x_shape[1]
         x = x.transpose([0, 2, 1]).reshape([B, self.dim, H, W])
         x = self.dwconv(x)

--- a/paddleseg/models/segformer.py
+++ b/paddleseg/models/segformer.py
@@ -5,6 +5,7 @@
 import paddle
 import paddle.nn as nn
 import paddle.nn.functional as F
+from paddle.fluid.dygraph.base import in_declarative_mode
 import numpy as np
 
 from paddleseg.cvlibs import manager
@@ -84,10 +85,10 @@ class SegFormer(nn.Layer):
         c1, c2, c3, c4 = feats
 
         ############## MLP decoder on C1-C4 ###########
-        c1_shape = paddle.shape(c1)
-        c2_shape = paddle.shape(c2)
-        c3_shape = paddle.shape(c3)
-        c4_shape = paddle.shape(c4)
+        c1_shape = c1.shape if in_declarative_mode() else paddle.shape(c1)
+        c2_shape = c2.shape if in_declarative_mode() else paddle.shape(c2)
+        c3_shape = c3.shape if in_declarative_mode() else paddle.shape(c3)
+        c4_shape = c4.shape if in_declarative_mode() else paddle.shape(c4)
 
         _c4 = self.linear_c4(c4).transpose([0, 2, 1]).reshape(
             [0, 0, c4_shape[2], c4_shape[3]])
@@ -123,7 +124,7 @@ class SegFormer(nn.Layer):
         return [
             F.interpolate(
                 logit,
-                size=paddle.shape(x)[2:],
+                size=x.shape[2:] if in_declarative_mode() else paddle.shape(x)[2:],
                 mode='bilinear',
                 align_corners=self.align_corners)
         ]


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
背景：由于组合算子目前对动态shape场景不支持，为了支持组合算子在模型库使用，需要对动转静场景下动态shape进行修改。
PR改动：在segformer_b0模型中新增动转静分支，在动转静场景下用tensor.shape替代paddle.shape。