### PR TITLE
add output annotations.json file for predict.py

### DIFF
--- a/paddleseg/core/predict.py
+++ b/paddleseg/core/predict.py
@@ -23,6 +23,10 @@ from paddleseg import utils
 from paddleseg.core import infer
 from paddleseg.utils import logger, progbar, visualize
 
+# import relevant modules
+from eiseg.util.polygon import get_polygon
+from qtpy import QtGui, QtCore, QtWidgets
+import json
 
 def mkdir(path):
     sub_dir = os.path.dirname(path)
@@ -44,6 +48,19 @@ def preprocess(im_path, transforms):
     data['img'] = paddle.to_tensor(data['img'])
     return data
 
+# convert various types of data into JSON format
+class NpEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, np.integer):
+            return int(obj)
+        elif isinstance(obj, np.floating):
+            return float(obj)
+        elif isinstance(obj, np.ndarray):
+            return obj.tolist()
+        elif isinstance(obj, datetime.datetime):
+        	return obj.strftime('%Y-%m-%dT%H:%M:%S')
+        else:
+            return super(NpEncoder, self).default(obj)
 
 def predict(model,
             model_path,
@@ -92,11 +109,32 @@ def predict(model,
 
     added_saved_dir = os.path.join(save_dir, 'added_prediction')
     pred_saved_dir = os.path.join(save_dir, 'pseudo_color_prediction')
-
+    json_saved_dir = os.path.join(save_dir, 'annotations')
+    
+    polygons = []
     logger.info("Start to predict...")
     progbar_pred = progbar.Progbar(target=len(img_lists[0]), verbose=1)
     color_map = visualize.get_color_map_list(256, custom_color=custom_color)
     with paddle.no_grad():
+        # define the nodes required for JSON, including images, colors, etc
+        images = []
+        annotations = []
+        categories = []
+        bk_color = {
+            "id": 1,
+            "name": "bk",
+            "color": [0,0,0],
+            "supercategory": "",               
+        }
+        categories.append(bk_color)
+        obj_color = {
+            "id": 2,
+            "name": "obj",
+            "color": [128,0,0],
+            "supercategory": "",               
+        }
+        categories.append(obj_color)
+        
         for i, im_path in enumerate(img_lists[local_rank]):
             data = preprocess(im_path, transforms)
 
@@ -121,6 +159,12 @@ def predict(model,
                     crop_size=crop_size)
             pred = paddle.squeeze(pred)
             pred = pred.numpy().astype('uint8')
+            
+            # obtain polygon vertices
+            polygons = get_polygon(
+                (pred * 255),
+                img_size=pred.shape,
+                building=False)
 
             # get the saved name
             if image_dir is not None:
@@ -146,5 +190,53 @@ def predict(model,
 
             progbar_pred.update(i + 1)
 
+
+            # define the information required for a single image
+            image = {
+                "id": i+1,
+                "width": pred.shape[1],
+                "height": pred.shape[0],
+                "file_name": im_file,
+                "license": "",
+                "flickr_url": "",
+                "coco_url": "",
+                "date_captured": ""                
+            }
+            images.append(image)
+			
+			# store polygon vertices in annotation
+            annotation = {
+                "id": i+1,
+                "iscrowd": 0,
+                "image_id": i+1,
+                "category_id": 2,
+                "segmentation": [],
+                "area": 0,
+                "bbox": [],
+            }
+            for polygon in polygons:
+                tmp = []
+                for p in polygon:
+                    tmp.append(p[0])
+                    tmp.append(p[1])
+                annotation["segmentation"].append(tmp)
+            annotations.append(annotation)
+        
+		# summarize all information together to form annotated data
+        jdata = {
+            "categories":[],
+            "images":[],
+            "annotations":[],
+            "info":"",
+            "licenses":[],
+        }
+        jdata["categories"]=categories
+        jdata["images"]=images        
+        jdata["annotations"]=annotations         
+    
+		# save JSON file
+        jsonPath = json_saved_dir + ".json"
+        open(jsonPath, "w", encoding="utf-8").write(json.dumps(jdata, cls=NpEncoder))
+		
     logger.info("Predicted images are saved in {} and {} .".format(
         added_saved_dir, pred_saved_dir))

--- a/paddleseg/core/predict.py
+++ b/paddleseg/core/predict.py
@@ -14,6 +14,7 @@
 
 import os
 import math
+import json
 
 import cv2
 import numpy as np
@@ -21,12 +22,9 @@ import paddle
 
 from paddleseg import utils
 from paddleseg.core import infer
+from eiseg.util.polygon import get_polygon
 from paddleseg.utils import logger, progbar, visualize
 
-# import relevant modules
-from eiseg.util.polygon import get_polygon
-from qtpy import QtGui, QtCore, QtWidgets
-import json
 
 def mkdir(path):
     sub_dir = os.path.dirname(path)
@@ -48,6 +46,7 @@ def preprocess(im_path, transforms):
     data['img'] = paddle.to_tensor(data['img'])
     return data
 
+
 # convert various types of data into JSON format
 class NpEncoder(json.JSONEncoder):
     def default(self, obj):
@@ -58,9 +57,10 @@ class NpEncoder(json.JSONEncoder):
         elif isinstance(obj, np.ndarray):
             return obj.tolist()
         elif isinstance(obj, datetime.datetime):
-        	return obj.strftime('%Y-%m-%dT%H:%M:%S')
+            return obj.strftime('%Y-%m-%dT%H:%M:%S')
         else:
             return super(NpEncoder, self).default(obj)
+
 
 def predict(model,
             model_path,
@@ -109,8 +109,8 @@ def predict(model,
 
     added_saved_dir = os.path.join(save_dir, 'added_prediction')
     pred_saved_dir = os.path.join(save_dir, 'pseudo_color_prediction')
-    json_saved_dir = os.path.join(save_dir, 'annotations')
-    
+    json_saved_name = os.path.join(save_dir, 'annotations.json')
+
     polygons = []
     logger.info("Start to predict...")
     progbar_pred = progbar.Progbar(target=len(img_lists[0]), verbose=1)
@@ -123,18 +123,18 @@ def predict(model,
         bk_color = {
             "id": 1,
             "name": "bk",
-            "color": [0,0,0],
-            "supercategory": "",               
+            "color": [0, 0, 0],
+            "supercategory": "",
         }
         categories.append(bk_color)
         obj_color = {
             "id": 2,
             "name": "obj",
-            "color": [128,0,0],
-            "supercategory": "",               
+            "color": [128, 0, 0],
+            "supercategory": "",
         }
         categories.append(obj_color)
-        
+
         for i, im_path in enumerate(img_lists[local_rank]):
             data = preprocess(im_path, transforms)
 
@@ -159,12 +159,10 @@ def predict(model,
                     crop_size=crop_size)
             pred = paddle.squeeze(pred)
             pred = pred.numpy().astype('uint8')
-            
+
             # obtain polygon vertices
             polygons = get_polygon(
-                (pred * 255),
-                img_size=pred.shape,
-                building=False)
+                (pred * 255), img_size=pred.shape, building=False)
 
             # get the saved name
             if image_dir is not None:
@@ -190,25 +188,24 @@ def predict(model,
 
             progbar_pred.update(i + 1)
 
-
             # define the information required for a single image
             image = {
-                "id": i+1,
+                "id": i + 1,
                 "width": pred.shape[1],
                 "height": pred.shape[0],
                 "file_name": im_file,
                 "license": "",
                 "flickr_url": "",
                 "coco_url": "",
-                "date_captured": ""                
+                "date_captured": ""
             }
             images.append(image)
-			
-			# store polygon vertices in annotation
+
+            # store polygon vertices in annotation
             annotation = {
-                "id": i+1,
+                "id": i + 1,
                 "iscrowd": 0,
-                "image_id": i+1,
+                "image_id": i + 1,
                 "category_id": 2,
                 "segmentation": [],
                 "area": 0,
@@ -221,22 +218,24 @@ def predict(model,
                     tmp.append(p[1])
                 annotation["segmentation"].append(tmp)
             annotations.append(annotation)
-        
-		# summarize all information together to form annotated data
-        jdata = {
-            "categories":[],
-            "images":[],
-            "annotations":[],
-            "info":"",
-            "licenses":[],
+
+        # summarize all information together to form annotated data
+        json_data = {
+            "categories": [],
+            "images": [],
+            "annotations": [],
+            "info": "",
+            "licenses": [],
         }
-        jdata["categories"]=categories
-        jdata["images"]=images        
-        jdata["annotations"]=annotations         
-    
-		# save JSON file
-        jsonPath = json_saved_dir + ".json"
-        open(jsonPath, "w", encoding="utf-8").write(json.dumps(jdata, cls=NpEncoder))
-		
+        json_data["categories"] = categories
+        json_data["images"] = images
+        json_data["annotations"] = annotations
+
+        # save JSON file
+        open(
+            json_saved_name, "w",
+            encoding="utf-8").write(json.dumps(
+                json_data, cls=NpEncoder))
+
     logger.info("Predicted images are saved in {} and {} .".format(
         added_saved_dir, pred_saved_dir))


### PR DESCRIPTION
PR types： New features
PR changes：Others
Description：
基于PaddleSeg，形成标注和训练相结合的闭环；
修改predict.py，可以输出annotations.json；
此json文件可以用于PaddleSeg对分割区域进行调整，之后可以用于后续的训练。
循环往复；随着数据一批批的添加，训练出来的模型更加精准，所需微调的mask越少。
详细汇报内容已经写在“基于PaddleSeg实现标注与训练的闭环[工程化经验]”中，请审核。
https://aistudio.baidu.com/aistudio/projectdetail/5935376