### PR TITLE
add output annotations.json file for predict.py

### DIFF
--- a/docs/pr/pr/pr.md
+++ b/docs/pr/pr/pr.md
@@ -97,7 +97,7 @@ git add README.md
 pre-commit
 ```
 
-Repeat the above steps until the pre-comit format check does not report an error as follows:
+Repeat the above steps until the pre-commit format check does not report an error as follows:
 
 ![img](../images/003_precommit_pass.png)
 

--- a/docs/pr/pr/pr_cn.md
+++ b/docs/pr/pr/pr_cn.md
@@ -100,7 +100,7 @@ git add README.md
 pre-commit
 ```
 
-重复上述步骤，直到pre-comit格式检查不报错。如下所示。
+重复上述步骤，直到pre-commit格式检查不报错。如下所示。
 
 ![img](../images/003_precommit_pass.png)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ filelock
 scipy
 prettytable
 scikit-learn
+eiseg==1.1.1


### PR DESCRIPTION
PR types： New features
PR changes：Others
Description：
基于PaddleSeg，形成标注和训练相结合的闭环；
修改predict.py，可以输出annotations.json；
此json文件可以用于PaddleSeg对分割区域进行调整，之后可以用于后续的训练。
循环往复；随着数据一批批的添加，训练出来的模型更加精准，所需微调的mask越少。
详细汇报内容已经写在“基于PaddleSeg实现标注与训练的闭环[工程化经验]”中，请审核。
https://aistudio.baidu.com/aistudio/projectdetail/5935376