### PR TITLE
Update MT_dataset.py

### DIFF
--- a/contrib/QualityInspector/tools/dataset/MT_dataset.py
+++ b/contrib/QualityInspector/tools/dataset/MT_dataset.py
@@ -58,7 +58,7 @@ def _create_output_path(output_path):
     Create output directories for training and validation images and annotations.
     """
     image_output_path = os.path.join(output_path, "images")
-    anno_output_path = os.path.join(output_path, "anno")
+    anno_output_path = os.path.join(output_path, "annos")
     train_img_path = os.path.join(image_output_path, "train")
     val_img_path = os.path.join(image_output_path, "val")
     train_anno_path = os.path.join(anno_output_path, "train")


### PR DESCRIPTION
change anno_output_path to "annos" instead of "anno".

1. copy the code snippet in the readme and execute it : python3 tools/convert_tools/convert_mask_to_coco.py --image_path dataset/MT_dataset/images/train --anno_path dataset/MT_dataset/annos/train --class_num 5 --label_file dataset/MT_dataset/mt_catIDs.json --output_name dataset/MT_dataset/train.json --suffix .png

2. there is a exception: FileNotFoundError: dataset/MT_dataset/annos/train/exp1_num_108719.png is not found.

3. the root cause is the "anno" and "annos" are not consistent in the docs and code.

to align with "images", the "anno" should be "annos"

### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
