### PR TITLE
make pointrend & isanet adaptive to 0d-output for __getitem__ 

### DIFF
--- a/paddleseg/models/isanet.py
+++ b/paddleseg/models/isanet.py
@@ -123,10 +123,10 @@ class ISAHead(nn.Layer):
         x = self.in_conv(C4)
         x_shape = paddle.shape(x)
         P_h, P_w = self.down_factor
-        Q_h, Q_w = paddle.ceil(x_shape[2] / P_h).astype('int32'), paddle.ceil(
-            x_shape[3] / P_w).astype('int32')
-        pad_h, pad_w = (Q_h * P_h - x_shape[2]).astype('int32'), (
-            Q_w * P_w - x_shape[3]).astype('int32')
+        Q_h, Q_w = paddle.ceil(x_shape[2:3] / P_h).astype('int32'), paddle.ceil(
+            x_shape[3:4] / P_w).astype('int32')
+        pad_h, pad_w = (Q_h * P_h - x_shape[2:3]).astype('int32'), (
+            Q_w * P_w - x_shape[3:4]).astype('int32')
         if pad_h > 0 or pad_w > 0:
             padding = paddle.concat(
                 [

--- a/paddleseg/models/pointrend.py
+++ b/paddleseg/models/pointrend.py
@@ -419,9 +419,9 @@ class PointHead(nn.Layer):
 
         num_points = self.subdivision_num_points
         uncertainty_map = uncertainty_func(seg_logits)
-        batch_size = paddle.shape(uncertainty_map)[0]
-        height = paddle.shape(uncertainty_map)[2]
-        width = paddle.shape(uncertainty_map)[3]
+        batch_size = paddle.shape(uncertainty_map)[0:1]
+        height = paddle.shape(uncertainty_map)[2:3]
+        width = paddle.shape(uncertainty_map)[3:4]
         h_step = 1.0 / height
         w_step = 1.0 / width
 


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models
### Description
<!-- Describe what this PR does -->
This PR is to fix error brought by `__getitem__` output 0-D, including **pointrend** and **isanet**. 

For more detail, please see https://github.com/PaddlePaddle/Paddle/pull/52814 .



