### PR TITLE
fix pointrend with paddle.to_tensor 0d

### DIFF
--- a/paddleseg/models/pointrend.py
+++ b/paddleseg/models/pointrend.py
@@ -238,7 +238,7 @@ class PointHead(nn.Layer):
         self.scale_factor = scale_factor
         self.subdivision_steps = subdivision_steps
         self.subdivision_num_points = paddle.to_tensor(
-            subdivision_num_points, dtype="int32")
+            [subdivision_num_points], dtype="int32")
         self.dropout_ratio = dropout_ratio
         self.coarse_pred_each_layer = coarse_pred_each_layer
         self.align_corners = align_corners


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models
### Description
<!-- Describe what this PR does -->
This PR is to fix **pointrend** model error brought by `paddle.to_tensor(number)` 0-d output (in past, is 1-d). 

The Paddle PR is : https://github.com/PaddlePaddle/Paddle/pull/52741