### PR TITLE
fix opencv version

### DIFF
--- a/test_tipc/requirements.txt
+++ b/test_tipc/requirements.txt
@@ -3,7 +3,7 @@ yapf == 0.26.0
 flake8
 pyyaml >= 5.1
 visualdl >= 2.0.0
-opencv-python == 4.5.2.54
+opencv-python == 4.5.5.64
 tqdm
 filelock
 scipy


### PR DESCRIPTION
adapt to python3.10

### PR types
Others

### PR changes
Others

### Description
fix opencv version for adapting python3.10 in benchmark requirements
