### PR TITLE
Update text_to_sam_clip.py

### DIFF
--- a/contrib/SegmentAnything/scripts/text_to_sam_clip.py
+++ b/contrib/SegmentAnything/scripts/text_to_sam_clip.py
@@ -218,7 +218,7 @@ def gradio_display():
 
     demo = gr.TabbedInterface(
         [demo_mask_sam, ], ['SAM+CLIP(Text to Segment)'],
-        title=" 🔥 Text to Segment Anything with PaddleSeg 🔥")
+        theme=" 🔥 Text to Segment Anything with PaddleSeg 🔥")
     demo.launch(
         server_name="0.0.0.0", enable_queue=False, server_port=8078, share=True)
 


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
APIs

### Description
<!-- Describe what this PR does -->
The argument passed to the `TabbedInterface` of gradio is outdated. Now, instead of the argument `title`, it is `theme`. Because of this running the command: 
> python scripts/text_to_sam_clip.py --model-type vit_h

fails with the error: 
> TypeError: TabbedInterface.__init__() got an unexpected keyword argument 'title'.

Hence this commit, resolved this error by updating the argument passed.

