### PR TITLE
fix the error of defined more than once

### DIFF
--- a/deploy/cpp/src/test_seg.cc
+++ b/deploy/cpp/src/test_seg.cc
@@ -16,12 +16,12 @@
 DEFINE_string(model_dir, "", "Directory of the inference model. "
                              "It constains deploy.yaml and infer models");
 DEFINE_string(img_path, "", "Path of the test image.");
-DECLARE_string(devices);
+DECLARE_string(devices);  // 'devices' was already defined in paddle/fluid/inference/io.cc
 DEFINE_bool(use_trt, false, "Wether enable TensorRT when use GPU. Defualt: false.");
 DEFINE_string(trt_precision, "fp32", "The precision of TensorRT, support fp32, fp16 and int8. Default: fp32");
 DEFINE_bool(use_trt_dynamic_shape, false, "Wether enable dynamic shape when use GPU and TensorRT. Defualt: false.");
 DEFINE_string(dynamic_shape_path, "", "If set dynamic_shape_path, it read the dynamic shape for TRT.");
-DECLARE_bool(use_mkldnn);
+DECLARE_bool(use_mkldnn);  // 'use_mkldnn' was already defined in paddle/phi/core/flags.cc
 DEFINE_string(save_dir, "", "Directory of the output image.");
 
 typedef struct YamlConfig {

--- a/deploy/cpp/src/test_seg.cc
+++ b/deploy/cpp/src/test_seg.cc
@@ -16,12 +16,12 @@
 DEFINE_string(model_dir, "", "Directory of the inference model. "
                              "It constains deploy.yaml and infer models");
 DEFINE_string(img_path, "", "Path of the test image.");
-DEFINE_string(devices, "GPU", "Use GPU or CPU devices. Default: GPU");
+DECLARE_string(devices);
 DEFINE_bool(use_trt, false, "Wether enable TensorRT when use GPU. Defualt: false.");
 DEFINE_string(trt_precision, "fp32", "The precision of TensorRT, support fp32, fp16 and int8. Default: fp32");
 DEFINE_bool(use_trt_dynamic_shape, false, "Wether enable dynamic shape when use GPU and TensorRT. Defualt: false.");
 DEFINE_string(dynamic_shape_path, "", "If set dynamic_shape_path, it read the dynamic shape for TRT.");
-DEFINE_bool(use_mkldnn, false, "Wether enable MKLDNN when use CPU. Defualt: false.");
+DECLARE_bool(use_mkldnn);
 DEFINE_string(save_dir, "", "Directory of the output image.");
 
 typedef struct YamlConfig {

--- a/deploy/cpp/src/test_seg.cc
+++ b/deploy/cpp/src/test_seg.cc
@@ -16,12 +16,12 @@
 DEFINE_string(model_dir, "", "Directory of the inference model. "
                              "It constains deploy.yaml and infer models");
 DEFINE_string(img_path, "", "Path of the test image.");
-DECLARE_string(devices);  // 'devices' was already defined in paddle/fluid/inference/io.cc
+DECLARE_string(devices);  // 'devices' was already defined in paddle/fluid/inference/io.cc: "(devices, "", "The devices to be used which is joined by comma.");"
 DEFINE_bool(use_trt, false, "Wether enable TensorRT when use GPU. Defualt: false.");
 DEFINE_string(trt_precision, "fp32", "The precision of TensorRT, support fp32, fp16 and int8. Default: fp32");
 DEFINE_bool(use_trt_dynamic_shape, false, "Wether enable dynamic shape when use GPU and TensorRT. Defualt: false.");
 DEFINE_string(dynamic_shape_path, "", "If set dynamic_shape_path, it read the dynamic shape for TRT.");
-DECLARE_bool(use_mkldnn);  // 'use_mkldnn' was already defined in paddle/phi/core/flags.cc
+DECLARE_bool(use_mkldnn);  // 'use_mkldnn' was already defined in paddle/phi/core/flags.cc: "(use_mkldnn, false, "Use MKLDNN to run");"
 DEFINE_string(save_dir, "", "Directory of the output image.");
 
 typedef struct YamlConfig {


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
fix the ERROR: "flag 'devices' or 'use_mkldnn' was defined more than once" in cpp inference to adapt the change of Paddle.
<img width="354" alt="37091a405e36be4eff796689ead2e1d7" src="https://github.com/PaddlePaddle/PaddleSeg/assets/49938469/02942b36-81c3-4c41-b5ed-498453e18fed">


1. 'devices' was defined twice in https://github.com/PaddlePaddle/Paddle/blob/64ecdc03db38377e37a1c149086c1eb8700c3e04/paddle/fluid/inference/io.cc#L32 and https://github.com/PaddlePaddle/PaddleSeg/blob/92ab2be07ee95feab8f0025352abad4da00df3a7/deploy/cpp/src/test_seg.cc#L19
2. 'use_mkldnn' was defined twice in https://github.com/PaddlePaddle/Paddle/blob/64ecdc03db38377e37a1c149086c1eb8700c3e04/paddle/phi/core/flags.cc#LL682C30-L682C30 and https://github.com/PaddlePaddle/PaddleSeg/blob/92ab2be07ee95feab8f0025352abad4da00df3a7/deploy/cpp/src/test_seg.cc#L24
