### PR TITLE
Toward Devkit Consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,7 +92,6 @@ celerybeat-schedule
 # Environments
 .env
 .venv
-env/
 venv/
 ENV/
 env.bak/

--- a/Matting/docs/full_develop_cn.md
+++ b/Matting/docs/full_develop_cn.md
@@ -33,6 +33,7 @@ git clone https://github.com/PaddlePaddle/PaddleSeg
 
 ```shell
 cd PaddleSeg/Matting
+pip install "paddleseg>=2.5"
 pip install -r requirements.txt
 ```
 

--- a/Matting/docs/full_develop_en.md
+++ b/Matting/docs/full_develop_en.md
@@ -33,6 +33,7 @@ git clone https://github.com/PaddlePaddle/PaddleSeg
 
 ```shell
 cd PaddleSeg/Matting
+pip install "paddleseg>=2.5"
 pip install -r requirements.txt
 ```
 

--- a/Matting/docs/quick_start_cn.md
+++ b/Matting/docs/quick_start_cn.md
@@ -23,6 +23,7 @@ git clone https://github.com/PaddlePaddle/PaddleSeg
 
 ```shell
 cd PaddleSeg/Matting
+pip install "paddleseg>=2.5"
 pip install -r requirements.txt
 ```
 

--- a/Matting/docs/quick_start_en.md
+++ b/Matting/docs/quick_start_en.md
@@ -23,6 +23,7 @@ git clone https://github.com/PaddlePaddle/PaddleSeg
 
 ```shell
 cd PaddleSeg/Matting
+pip install "paddleseg>=2.5"
 pip install -r requirements.txt
 ```
 

--- a/Matting/requirements.txt
+++ b/Matting/requirements.txt
@@ -1,4 +1,4 @@
-paddleseg >= 2.5
+# paddleseg >= 2.5
 pymatting
 scikit-image
 numba

--- a/Matting/tools/export.py
+++ b/Matting/tools/export.py
@@ -65,7 +65,10 @@ def parse_args():
         help="Export the model with fixed input shape, such as 1 3 1024 1024.",
         type=int,
         default=None)
-    parser.add_argument('--for_fd', action='store_true')
+    parser.add_argument(
+        '--for_fd',
+        action='store_true',
+        help="Export the model to FD-compatible format.")
 
     return parser.parse_args()
 

--- a/deploy/slim/quant/qat_export.py
+++ b/deploy/slim/quant/qat_export.py
@@ -58,7 +58,10 @@ def parse_args():
         dest='with_softmax',
         help='Add the softmax operation at the end of the network',
         action='store_true')
-    parser.add_argument('--for_fd', action='store_true')
+    parser.add_argument(
+        '--for_fd',
+        action='store_true',
+        help="Export the model to FD-compatible format.")
 
     return parser.parse_args()
 

--- a/deploy/slim/quant/qat_export.py
+++ b/deploy/slim/quant/qat_export.py
@@ -33,6 +33,12 @@ def parse_args():
     parser.add_argument(
         '--model_path', help='The path of model for export', type=str)
     parser.add_argument(
+        "--input_shape",
+        nargs='+',
+        help="Export the model with fixed input shape, e.g., `--input_shape 1 3 1024 1024`.",
+        type=int,
+        default=None)
+    parser.add_argument(
         '--save_dir',
         help='The directory for saving the exported model',
         type=str,
@@ -52,6 +58,7 @@ def parse_args():
         dest='with_softmax',
         help='Add the softmax operation at the end of the network',
         action='store_true')
+    parser.add_argument('--for_fd', action='store_true')
 
     return parser.parse_args()
 
@@ -85,14 +92,19 @@ def main(args):
     new_net = net if output_op == 'none' else WrappedModel(net, output_op)
 
     new_net.eval()
-    save_path = os.path.join(args.save_dir, 'model')
-    input_spec = [
-        paddle.static.InputSpec(
-            shape=[None, 3, None, None], dtype='float32')
-    ]
+    if args.for_fd:
+        save_name = 'inference'
+        yaml_name = 'inference.yml'
+    else:
+        save_name = 'model'
+        yaml_name = 'deploy.yaml'
+    save_path = os.path.join(args.save_dir, save_name)
+    shape = [None, 3, None, None] if args.input_shape is None \
+        else args.input_shape
+    input_spec = [paddle.static.InputSpec(shape=shape, dtype='float32')]
     quantizer.save_quantized_model(new_net, save_path, input_spec=input_spec)
 
-    yml_file = os.path.join(args.save_dir, 'deploy.yaml')
+    yml_file = os.path.join(args.save_dir, yaml_name)
     with open(yml_file, 'w') as file:
         transforms = cfg.val_dataset_cfg.get('transforms', [{
             'type': 'Normalize'
@@ -100,8 +112,8 @@ def main(args):
         data = {
             'Deploy': {
                 'transforms': transforms,
-                'model': 'model.pdmodel',
-                'params': 'model.pdiparams'
+                'model': save_name + '.pdmodel',
+                'params': save_name + '.pdiparams'
             }
         }
         yaml.dump(data, file)

--- a/paddleseg/utils/metrics.py
+++ b/paddleseg/utils/metrics.py
@@ -130,7 +130,7 @@ def mean_iou(intersect_area, pred_area, label_area):
             iou = 0
         else:
             iou = intersect_area[i] / union[i]
-        class_iou.append(iou)
+        class_iou.append(float(iou))
     miou = np.mean(class_iou)
     return np.array(class_iou), miou
 
@@ -158,7 +158,7 @@ def dice(intersect_area, pred_area, label_area):
             dice = 0
         else:
             dice = (2 * intersect_area[i]) / union[i]
-        class_dice.append(dice)
+        class_dice.append(float(dice))
     mdice = np.mean(class_dice)
     return np.array(class_dice), mdice
 
@@ -184,7 +184,7 @@ def accuracy(intersect_area, pred_area):
             acc = 0
         else:
             acc = intersect_area[i] / pred_area[i]
-        class_acc.append(acc)
+        class_acc.append(float(acc))
     macc = np.sum(intersect_area) / np.sum(pred_area)
     return np.array(class_acc), macc
 
@@ -215,8 +215,8 @@ def class_measurement(intersect_area, pred_area, label_area):
             else intersect_area[i] / pred_area[i]
         recall = 0 if label_area[i] == 0 \
             else intersect_area[i] / label_area[i]
-        class_precision.append(precision)
-        class_recall.append(recall)
+        class_precision.append(float(precision))
+        class_recall.append(float(recall))
 
     return mean_acc, np.array(class_precision), np.array(class_recall)
 

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     author='PaddlePaddle Author',
     author_email='',
     install_requires=REQUIRED_PACKAGES,
-    packages=find_packages(),
+    packages=find_packages(include=['paddleseg', 'paddleseg.*']),
     # PyPI package information.
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tools/export.py
+++ b/tools/export.py
@@ -48,7 +48,10 @@ def parse_args():
         help="Select the op to be appended to the last of inference model, default: argmax."
         "In PaddleSeg, the output of trained model is logit (H*C*H*W). We can apply argmax and"
         "softmax op to the logit according the actual situation.")
-    parser.add_argument('--for_fd', action='store_true')
+    parser.add_argument(
+        '--for_fd',
+        action='store_true',
+        help="Export the model to FD-compatible format.")
 
     return parser.parse_args()
 

--- a/tools/export.py
+++ b/tools/export.py
@@ -48,6 +48,7 @@ def parse_args():
         help="Select the op to be appended to the last of inference model, default: argmax."
         "In PaddleSeg, the output of trained model is logit (H*C*H*W). We can apply argmax and"
         "softmax op to the logit according the actual situation.")
+    parser.add_argument('--for_fd', action='store_true')
 
     return parser.parse_args()
 
@@ -76,7 +77,13 @@ def main(args):
     input_spec = [paddle.static.InputSpec(shape=shape, dtype='float32')]
     model.eval()
     model = paddle.jit.to_static(model, input_spec=input_spec)
-    paddle.jit.save(model, os.path.join(args.save_dir, 'model'))
+    if args.for_fd:
+        save_name = 'inference'
+        yaml_name = 'inference.yml'
+    else:
+        save_name = 'model'
+        yaml_name = 'deploy.yaml'
+    paddle.jit.save(model, os.path.join(args.save_dir, save_name))
 
     # save deploy.yaml
     val_dataset_cfg = cfg.val_dataset_cfg
@@ -87,8 +94,8 @@ def main(args):
     # TODO add test config
     deploy_info = {
         'Deploy': {
-            'model': 'model.pdmodel',
-            'params': 'model.pdiparams',
+            'model': save_name + '.pdmodel',
+            'params': save_name + '.pdiparams',
             'transforms': transforms,
             'input_shape': shape,
             'output_op': args.output_op,
@@ -99,7 +106,7 @@ def main(args):
     msg += str(yaml.dump(deploy_info))
     logger.info(msg)
 
-    yml_file = os.path.join(args.save_dir, 'deploy.yaml')
+    yml_file = os.path.join(args.save_dir, yaml_name)
     with open(yml_file, 'w') as file:
         yaml.dump(deploy_info, file)
 


### PR DESCRIPTION
## 目标

修改代码以提升PaddleCV套件一致性，同时适配X项目。修改后，套件应满足如下一致性要求：

1. 将训练过程中最优（一般是验证集上精度最高）的模型权重存储在输出目录的`best_model`子目录中，文件命名为`model.pdparams`。与之相配套的优化器参数（如果存储的话）文件命名为`model.pdopt`，也存储在该目录中。
2. 支持将训练、验证过程中VisualDL产生的.log格式日志文件保存在输出目录中（无嵌套子目录）。
3. 套件根目录存在`requirements.txt`文件，指定使用套件基础功能需要的依赖。在套件根目录可通过`pip install .`或`pip install -e .`方式（至少其中一种）安装套件核心库。
4. 对于模型导出功能，默认支持或通过命令行选项/配置文件等手段支持导出为FD格式。『FD格式』的导出结果通常包含如下文件：
- `inference.pdiparams`：保存权重参数。
- `inference.pdiparams.info`：保存与参数有关的额外信息。
- `inference.pdmodel`：保存模型结构描述信息。
- （可选）`inference.yml`：预处理配置文件。

## 代码变动

1. 【一致性提升】`tools/export.py`和`deploy/slim/quant/qat_export.py`支持`--for_fd`命令行选项，以控制是否将模型导出为FD格式。
2. 【bug修复】计算精度指标时进行显式类型转换，以避免某些NumPy版本可能出现的部分类别精度为0时数组数据类型不正确的情况。
3. 【功能增强】为`deploy/slim/quant/qat_export.py`增加fixed input shape支持。
4. 【功能增强】使`setup.py`仅安装`paddleseg`目录中的内容，以避免其它非关键目录（若其中也包含`__init__.py`，则被识别为regular package）也一并被安装，并导致预期外的错误。

## 其它变动

1. 【功能增强】从Matting的依赖列表（`Matting/requirements.txt`）中去除`paddleseg`，改为在文档中提示用户单独安装，以更方便PaddleSeg版本管理。
2. 【bug修复】在`.gitignore`中去除了`env/`，防止`paddleseg/utils/env/`被Git排除在版本控制内容之外。

