### PR TITLE
paddle support stride, fix oom

### DIFF
--- a/paddleseg/models/losses/semantic_connectivity_loss.py
+++ b/paddleseg/models/losses/semantic_connectivity_loss.py
@@ -142,7 +142,7 @@ def compute_class_connectiveity(pred_conn, label_conn, pred_num_conn,
         pair_conn_num = 0
 
         for j in range(1, pred_num_conn):
-            pred_j_mask = pred_conn[:, :, j]
+            pred_j_mask = pred_conn[:, :, j].contiguous()
             pred_j = pred_j_mask * pred
 
             iou = compute_iou(pred_j, label_i, zero)

--- a/paddleseg/models/losses/semantic_connectivity_loss.py
+++ b/paddleseg/models/losses/semantic_connectivity_loss.py
@@ -142,7 +142,10 @@ def compute_class_connectiveity(pred_conn, label_conn, pred_num_conn,
         pair_conn_num = 0
 
         for j in range(1, pred_num_conn):
-            pred_j_mask = pred_conn[:, :, j].contiguous()
+            if hasattr(paddle.Tensor, "contiguous"):
+                pred_j_mask = pred_conn[:, :, j].contiguous()
+            else:
+                pred_j_mask = pred_conn[:, :, j]
             pred_j = pred_j_mask * pred
 
             iou = compute_iou(pred_j, label_i, zero)


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
Paddle支持stride后，Tensor 显存的生命周期有所变化。这导致test_configs^fastscnn^fastscnn_cityscapes_1024x1024_40k_SCL train_static_multi出现OOM。本PR能够修复该问题。