### PR TITLE
support stride and speed up

### DIFF
--- a/paddleseg/models/losses/ohem_cross_entropy_loss.py
+++ b/paddleseg/models/losses/ohem_cross_entropy_loss.py
@@ -76,7 +76,7 @@ class OhemCrossEntropyLoss(nn.Layer):
             threshold = self.thresh
             if self.min_kept > 0:
                 index = prob.argsort()
-                threshold_index = index[min(len(index), self.min_kept) - 1]
+                threshold_index = index[min(len(index), self.min_kept) - 1].contiguous()
                 threshold_index = int(threshold_index)
                 if prob[threshold_index] > self.thresh:
                     threshold = prob[threshold_index]

--- a/paddleseg/models/losses/ohem_cross_entropy_loss.py
+++ b/paddleseg/models/losses/ohem_cross_entropy_loss.py
@@ -76,7 +76,10 @@ class OhemCrossEntropyLoss(nn.Layer):
             threshold = self.thresh
             if self.min_kept > 0:
                 index = prob.argsort()
-                threshold_index = index[min(len(index), self.min_kept) - 1].contiguous()
+                if hasattr(paddle.Tensor, "contiguous"):
+                    threshold_index = index[min(len(index), self.min_kept) - 1].contiguous()
+                else:
+                    threshold_index = index[min(len(index), self.min_kept) - 1]
                 threshold_index = int(threshold_index)
                 if prob[threshold_index] > self.thresh:
                     threshold = prob[threshold_index]


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what this PR does -->
Paddle支持stride后，slice、split等共享显存。小Tensor的numpy会拷贝全部的大Tensor的显存。竞品也是这么做的。这有时候会导致numpy()的速度变慢进而进行模型的性能。本PR修复1个这样的问题。