### PR TITLE
[cherry-pick #3424]fix 0D array error

### DIFF
--- a/paddleseg/core/train.py
+++ b/paddleseg/core/train.py
@@ -270,7 +270,7 @@ def train(model,
 
             if (iter) % log_iters == 0 and local_rank == 0:
                 avg_loss /= log_iters
-                avg_loss_list = [float(l) / log_iters for l in avg_loss_list]
+                avg_loss_list = [l / log_iters for l in avg_loss_list]
                 remain_iters = iters - iter
                 avg_train_batch_cost = batch_cost_averager.get_average()
                 avg_train_reader_cost = reader_cost_averager.get_average()

--- a/paddleseg/core/train.py
+++ b/paddleseg/core/train.py
@@ -270,7 +270,7 @@ def train(model,
 
             if (iter) % log_iters == 0 and local_rank == 0:
                 avg_loss /= log_iters
-                avg_loss_list = [l[0] / log_iters for l in avg_loss_list]
+                avg_loss_list = [float(l) / log_iters for l in avg_loss_list]
                 remain_iters = iters - iter
                 avg_train_batch_cost = batch_cost_averager.get_average()
                 avg_train_reader_cost = reader_cost_averager.get_average()

--- a/paddleseg/core/train.py
+++ b/paddleseg/core/train.py
@@ -261,10 +261,10 @@ def train(model,
             model.clear_gradients()
             avg_loss += float(loss)
             if not avg_loss_list:
-                avg_loss_list = [l.numpy() for l in loss_list]
+                avg_loss_list = [float(l) for l in loss_list]
             else:
                 for i in range(len(loss_list)):
-                    avg_loss_list[i] += loss_list[i].numpy()
+                    avg_loss_list[i] += float(loss_list[i])
             batch_cost_averager.record(
                 time.time() - batch_start, num_samples=batch_size)
 


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others
### Description
<!-- Describe what this PR does -->
`avg_loss_list`中元素可能是shape为空的0维数组，对其索引会出现错误。cherry-pick自https://github.com/PaddlePaddle/PaddleSeg/pull/3423