### PR TITLE
[Fix]modify quantized ops during mkldnn int8 inference

### DIFF
--- a/deploy/slim/act/test_seg.py
+++ b/deploy/slim/act/test_seg.py
@@ -59,6 +59,8 @@ def load_predictor(args):
         if args.use_mkldnn:
             pred_cfg.enable_mkldnn()
             if args.precision == "int8":
+                # Please ensure that the quantized ops during inference are the same as
+                # the ops set in the qat training configuration file
                 pred_cfg.enable_mkldnn_int8({
                     "conv2d", "depthwise_conv2d", "pool2d", "elementwise_mul"
                 })

--- a/deploy/slim/act/test_seg.py
+++ b/deploy/slim/act/test_seg.py
@@ -61,9 +61,7 @@ def load_predictor(args):
             if args.precision == "int8":
                 # Please ensure that the quantized ops during inference are the same as
                 # the ops set in the qat training configuration file
-                pred_cfg.enable_mkldnn_int8({
-                    "conv2d", "depthwise_conv2d", "pool2d", "elementwise_mul"
-                })
+                pred_cfg.enable_mkldnn_int8({"conv2d", "depthwise_conv2d"})
 
     if args.use_trt:
         # To collect the dynamic shapes of inputs for TensorRT engine


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
在跑通act示例项目过程中发现CPU量化推理精度下降比较严重，发现是在测试的时候比量化训练多量化了`pool2d`以及`elementwise_mul`两个op，去掉之后推理精度恢复正常水平。下面是实验结果，都设置了`benchmark=True`：
|        | 原模型fp32推理 | 原模型fp32+mkldnn加速 | 量化模型int8推理（量化conv2d,depthwise_conv2d） | 量化模型int8推理（量化conv2d,depthwise_conv2d,elementwise_mul） | 量化模型int8推理（量化conv2d,depthwise_conv2d,elementwise_mul,pool2d） |
|:------:|:---------:|:----------------:|:-------------------------------------:|:-----------------------------------------------------:|:------------------------------------------------------------:|
|  mIoU  |  0.7704   |      0.7704      |                0.7658                 |                        0.7657                         |                            0.7372                            |
| 耗时（ms） |  1216.8   |      1191.3      |                 434.5                 |                         439.6                         |                            505.8                             |

