### PR TITLE
Modify the version to 2.9.1, because paddleseg cannot be imported from setup.py in some Docker environments.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,14 +16,12 @@
 from setuptools import find_packages
 from setuptools import setup
 
-import paddleseg
-
 with open("requirements.txt") as file:
     REQUIRED_PACKAGES = file.read()
 
 setup(
     name='paddleseg',
-    version=paddleseg.__version__.replace('-', ''),
+    version='2.9,1',
     description=('End-to-end image segmentation kit based on PaddlePaddle.'),
     long_description='',
     url='https://github.com/PaddlePaddle/PaddleSeg',


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

### Description
<!-- Describe what this PR does -->
