### PR TITLE
[FIX] fix mlu bugs about parameter 'ignore_index' in ohem_cross_entropy_loss.py

### DIFF
--- a/paddleseg/models/losses/ohem_cross_entropy_loss.py
+++ b/paddleseg/models/losses/ohem_cross_entropy_loss.py
@@ -19,6 +19,7 @@ import paddle.nn.functional as F
 from paddleseg.cvlibs import manager
 
 _IS_NPU = "npu" in paddle.get_device()
+_IS_MLU = "mlu" in paddle.get_device()
 
 
 @manager.LOSSES.add_component
@@ -120,6 +121,20 @@ class OhemCrossEntropyLoss(nn.Layer):
                               ignore_index=self.ignore_index,
                               reduction='none')
             loss = loss.unsqueeze(1)
+        elif _IS_MLU:
+            # mlu kernel does not deal with th parameter ignore_index
+            # so here manual solve it
+            logit_trans = logit.transpose((0, 2, 3, 1)).flatten(0, 2)
+            mask = label != self.ignore_index
+            label = paddle.where(mask, label, paddle.zeros_like(label))
+            label_trans = label.transpose((0, 2, 3, 1)).flatten(0, 2)
+            loss = F.cross_entropy(logit_trans,
+                                   label_trans,
+                                   weight=self.weight,
+                                   reduction='none',
+                                   axis=-1)
+            loss = loss.reshape([n, h, w, 1]).transpose([0, 3, 1, 2])
+            loss = loss * mask.astype("float32")
         else:
             loss = F.cross_entropy(logit,
                                    label,


### PR DESCRIPTION
[FIX] fix mlu bugs about parameter 'ignore_index' in ohem_cross_entropy_loss.py

### Description
manual deal with the parameter 'ignore_index' when training pplite-seg on mlu, because mlu cross_entropy kernel does not use the parameter 'ignore_index'.
