### PR TITLE
fix: when cudatoolkit not found the v will return as None type

### DIFF
--- a/paddleseg/utils/env/sys_env.py
+++ b/paddleseg/utils/env/sys_env.py
@@ -99,9 +99,10 @@ def get_sys_env():
         cuda_home = _find_cuda_home()
         env_info['NVCC'] = _get_nvcc_info(cuda_home)
         # refer to https://github.com/PaddlePaddle/Paddle/blob/release/2.0-rc/paddle/fluid/platform/device_context.cc#L327
-        v = paddle.get_cudnn_version()
-        v = str(v // 1000) + '.' + str(v % 1000 // 100)
-        env_info['cudnn'] = v
+        v = paddle.get_cudnn_version() #if cuda toolkit is not avaliable 
+        if v is not None:
+            v = str(v // 1000) + '.' + str(v % 1000 // 100)
+            env_info['cudnn'] = v
         if 'gpu' in paddle.get_device():
             gpu_nums = paddle.distributed.ParallelEnv().nranks
         else:


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

Bug fixes

### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->

APIs

### Description
<!-- Describe what this PR does -->

while checking the env info if cuda toolkit not installed then paddle not able to make it on cpu default. the v value is returned as Nonetype and after that you wil get error for doing the calculation on nonetype value. 

```bash

/home/server2/anaconda3/envs/paddleseg/lib/python3.10/site-packages/paddle/base/framework.py:688: UserWarning: You are using GPU version Paddle, but your CUDA device is not set properly. CPU device will be used by default.
  warnings.warn(
W0902 10:47:30.370355 1513691 dynamic_loader.cc:314] The third-party dynamic library (libcudnn.so) that Paddle depends on is not configured correctly. (error code is /usr/local/cuda/lib64/libcudnn.so: cannot open shared object file: No such file or directory)
  Suggestions:
  1. Check if the third-party dynamic library (e.g. CUDA, CUDNN) is installed correctly and its version is matched with paddlepaddle you installed.
  2. Configure third-party dynamic library environment variables as follows:
  - Linux: set LD_LIBRARY_PATH by `export LD_LIBRARY_PATH=...`
  - Windows: set PATH by `set PATH=XXX;
Traceback (most recent call last):
  File "/home/server2/Documents/paddleseg/PaddleSeg/tools/train.py", line 211, in <module>
    main(args)
  File "/home/server2/Documents/paddleseg/PaddleSeg/tools/train.py", line 152, in main
    utils.show_env_info()
  File "/home/server2/anaconda3/envs/paddleseg/lib/python3.10/site-packages/paddleseg/utils/utils.py", line 38, in show_env_info
    env_info = get_sys_env()
  File "/home/server2/anaconda3/envs/paddleseg/lib/python3.10/site-packages/paddleseg/utils/env/sys_env.py", line 103, in get_sys_env
    v = str(v // 1000) + '.' + str(v % 1000 // 100)
TypeError: unsupported operand type(s) for //: 'NoneType' and 'int'
```
