### PR TITLE
paddle.shape return int64

### DIFF
--- a/paddleseg/models/isanet.py
+++ b/paddleseg/models/isanet.py
@@ -122,7 +122,7 @@ class ISAHead(nn.Layer):
     def forward(self, feat_list):
         C3, C4 = feat_list
         x = self.in_conv(C4)
-        x_shape = paddle.shape(x)
+        x_shape = paddle.shape(x).astype('int32')
         P_h, P_w = self.down_factor
         Q_h, Q_w = paddle.ceil(x_shape[2:3] / P_h).astype('int32'), paddle.ceil(
             x_shape[3:4] / P_w).astype('int32')


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what this PR does -->
https://github.com/PaddlePaddle/Paddle/pull/69589 后 paddle.shape返回int64类型。属于Paddle的不兼容升级。需要在套件中适配。
