### PR TITLE
paddle.shape return int64

### DIFF
--- a/paddleseg/models/pointrend.py
+++ b/paddleseg/models/pointrend.py
@@ -238,7 +238,7 @@ class PointHead(nn.Layer):
         self.scale_factor = scale_factor
         self.subdivision_steps = subdivision_steps
         self.subdivision_num_points = paddle.to_tensor([subdivision_num_points],
-                                                       dtype="int32")
+                                                       dtype="int64")
         self.dropout_ratio = dropout_ratio
         self.coarse_pred_each_layer = coarse_pred_each_layer
         self.align_corners = align_corners


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Others 
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Others 
### Description
<!-- Describe what this PR does -->
https://github.com/PaddlePaddle/Paddle/pull/69589 后 paddle.shape返回int64类型。属于Paddle的不兼容升级。需要在套件中适配。
