### PR TITLE
convert elements of `dpr` in `mix_transformer` explicitly to float to avoid `BreakGraph`

### DIFF
--- a/paddleseg/models/backbones/mix_transformer.py
+++ b/paddleseg/models/backbones/mix_transformer.py
@@ -305,7 +305,7 @@ class MixVisionTransformer(nn.Layer):
 
         # transformer encoder
         dpr = [
-            x.numpy() for x in paddle.linspace(0, drop_path_rate, sum(depths))
+            x.item() for x in paddle.linspace(0, drop_path_rate, sum(depths))
         ]  # stochastic depth decay rule
         cur = 0
         self.block1 = nn.LayerList([


### PR DESCRIPTION
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Bug fixes
### PR changes
<!-- One of [ Models | APIs | Docs | Others ] -->
Models 
### Description
<!-- Describe what this PR does -->
对模型`PaddleSeg_segformer_b0_bs4_fp16`进行分析发现：
原本`dpr`当中的元素是`numpy.array`，会被作为参数传递给`paddleseg/models/backbones/transformer_utils.py`当中的`drop_path`函数，函数中`drop_prob == 0.`操作会产生一个`ObjectVariable`导致子图发生打断，降低动转静性能。
转换为`float`类型可以避免这一问题。